### PR TITLE
[LESSON] [KAN-17] 강좌 상세 조회 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -1,5 +1,6 @@
 package com.innerpeace.themoonha.domain.lesson.controller;
 
+import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
 import com.innerpeace.themoonha.domain.lesson.service.LessonService;
@@ -7,9 +8,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 강좌 컨트롤러
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * </pre>
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lesson")
@@ -17,10 +32,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class LessonController {
     private final LessonService lessonService;
 
+    /**
+     * 강좌 목록 조회
+     *
+     * @param lessonListRequest
+     * @author 손승완
+     */
     @GetMapping("/list")
     public ResponseEntity<LessonListResponse> lessonList(LessonListRequest lessonListRequest) {
-        LessonListResponse lessonList = lessonService.findLessonList(lessonListRequest);
-        log.info("lessonList = {}", lessonList);
-        return ResponseEntity.ok(lessonList);
+        return ResponseEntity.ok(lessonService.findLessonList(lessonListRequest));
+    }
+
+    /**
+     * 강좌 상세 조회
+     *
+     * @param lessonId
+     * @author 손승완
+     */
+    @GetMapping("/detail/{lessonId}")
+    public ResponseEntity<LessonDetailResponse> lessonDetail(@PathVariable Long lessonId) {
+        return ResponseEntity.ok(lessonService.findLessonDetail(lessonId));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonDTO.java
@@ -2,6 +2,19 @@ package com.innerpeace.themoonha.domain.lesson.dto;
 
 import lombok.*;
 
+
+/**
+ * 강좌 목록 내부 강좌 정보 DTO
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * </pre>
+ */
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonDetailResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonDetailResponse.java
@@ -1,0 +1,40 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 강좌 상세 응답 DTO
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25   손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LessonDetailResponse {
+    private Long lessonId;
+    private String title;
+    private String branchName;
+    private String period;
+    private String lessonTime;
+    private int cnt;
+    private String place;
+    private String tutorName;
+    private int cost;
+    private String summary;
+    private String curriculum;
+    private String supply;
+    private String thumbnailUrl;
+    private String previewVideoUrl;
+    private int tutorId;
+    private String tutorProfileImgUrl;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListResponse.java
@@ -4,6 +4,18 @@ import lombok.*;
 
 import java.util.List;
 
+/**
+ * 강좌 목록 응답 DTO
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * </pre>
+ */
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -3,9 +3,21 @@ package com.innerpeace.themoonha.domain.lesson.mapper;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
-
 import java.util.Optional;
 
+/**
+ * 강좌 매퍼
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * </pre>
+ */
 public interface LessonMapper {
     Optional<LessonListResponse> selectLessonList(LessonListRequest lessonListRequest);
 

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -1,5 +1,6 @@
 package com.innerpeace.themoonha.domain.lesson.mapper;
 
+import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
 
@@ -7,4 +8,6 @@ import java.util.Optional;
 
 public interface LessonMapper {
     Optional<LessonListResponse> selectLessonList(LessonListRequest lessonListRequest);
+
+    Optional<LessonDetailResponse> selectLessonDetail(Long lessonId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -5,7 +5,7 @@ import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
 
 /**
- * 강좌 서비스 인터페이체
+ * 강좌 서비스 인터페이스
  * @author 손승완
  * @since 2024.08.24
  * @version 1.0

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -1,8 +1,25 @@
 package com.innerpeace.themoonha.domain.lesson.service;
 
+import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
 
+/**
+ * 강좌 서비스 인터페이체
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * </pre>
+ */
 public interface LessonService {
     LessonListResponse findLessonList(LessonListRequest lessonListRequest);
+
+    LessonDetailResponse findLessonDetail(Long lessonId);
+
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -1,5 +1,6 @@
 package com.innerpeace.themoonha.domain.lesson.service;
 
+import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
 import com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper;
@@ -9,6 +10,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+/**
+ * 강좌 서비스 구현체
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * </pre>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -19,10 +33,17 @@ public class LessonServiceImpl implements LessonService {
     public LessonListResponse findLessonList(LessonListRequest lessonListRequest) {
         String memberName = "고객1"; // 임시값
         lessonListRequest.setLessonTime();
-        log.info("category = {}", lessonListRequest.getCategory());
+
         LessonListResponse lessonListResponse = lessonMapper.selectLessonList(lessonListRequest)
                 .orElseThrow(() -> new CustomException(ErrorCode.LESSON_NOT_FOUND));
         lessonListResponse.setMemberName(memberName);
+
         return lessonListResponse;
+    }
+
+    @Override
+    public LessonDetailResponse findLessonDetail(Long lessonId) {
+        return lessonMapper.selectLessonDetail(lessonId)
+                .orElseThrow(() -> new CustomException(ErrorCode.LESSON_NOT_FOUND));
     }
 }

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 강좌 매퍼 XML
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ==========  =========    =========
+ * 2024.08.24  	손승완        최초 생성
+ * 2024.08.25   손승완        강좌 상세 조회 쿼리 추가
+ * </pre>
+ -->
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
 
     <resultMap id="LessonListResponseMap" type="com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse">

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -110,4 +110,39 @@
             </if>
         </where>
     </select>
+
+    <select id="selectLessonDetail"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse">
+        select
+            l.lesson_id,
+            l.title,
+            b.name branch_name,
+            l.start_date || '~' || l.end_date period,
+            CASE
+                WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time END AS lesson_time,
+            l.cnt,
+            l.place,
+            m.name tutor_name,
+            l.cost,
+            l.summary,
+            l.curriculum,
+            l.supply,
+            l.thumbnail_url,
+            l.preview_video_url,
+            m.member_id tutor_id,
+            m.profile_img_url tutor_profile_img_url
+        from
+            lesson l
+        join
+            branch b
+        on
+            l.branch_id = b.branch_id
+        join
+            member m
+        on
+            l.member_id = m.member_id
+        where
+            l.lesson_id = #{lessonId}
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
강좌 상세 조회 API를 구현했습니다.

## ⭐️ 관련 이슈
- closes : #4 

## 📍 작업한 내용
- 강좌 상세 조회 API 구현

## 🔎 결과 및 이슈 공유
cnt가 1일때와 2이상일때의 period 반환을 다르게 주도록 했습니다.

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/4ab7fa79-b009-4621-b195-f46c90aa83e4">

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/fc56c678-50a3-416e-b051-4c6f44a3482b">

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
