### PR TITLE
[LESSON] [KAN-59] 금주의 1분 강좌(숏폼) 상세 조회 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -3,6 +3,7 @@ package com.innerpeace.themoonha.domain.lesson.controller;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.service.LessonService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
  * ----------  --------    ---------------------------
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * </pre>
  */
 @RestController
@@ -52,5 +54,16 @@ public class LessonController {
     @GetMapping("/detail/{lessonId}")
     public ResponseEntity<LessonDetailResponse> lessonDetail(@PathVariable Long lessonId) {
         return ResponseEntity.ok(lessonService.findLessonDetail(lessonId));
+    }
+
+    /**
+     * 숏폼 상세 조회
+     *
+     * @param shortFormId
+     * @author 손승완
+     */
+    @GetMapping("/shortform/{shortFormId}")
+    public ResponseEntity<ShortFormDetailResponse> shortFormDetail(@PathVariable Long shortFormId) {
+        return ResponseEntity.ok(lessonService.findShortFormDetail(shortFormId));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/ShortFormDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/ShortFormDTO.java
@@ -2,6 +2,18 @@ package com.innerpeace.themoonha.domain.lesson.dto;
 
 import lombok.*;
 
+/**
+ * 숏폼 목록 조회 시 숏폼 내용 DTO
+ * @author 손승완
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.24  	손승완       최초 생성
+ * </pre>
+ */
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/ShortFormDetailResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/ShortFormDetailResponse.java
@@ -1,0 +1,29 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 숏폼 상세 조회 DTO
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShortFormDetailResponse {
+    private Long lessonId;
+    private String tutorName;
+    private String shortFormName;
+    private String lessonTitle;
+    private String videoUrl;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -3,6 +3,8 @@ package com.innerpeace.themoonha.domain.lesson.mapper;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
+
 import java.util.Optional;
 
 /**
@@ -22,4 +24,6 @@ public interface LessonMapper {
     Optional<LessonListResponse> selectLessonList(LessonListRequest lessonListRequest);
 
     Optional<LessonDetailResponse> selectLessonDetail(Long lessonId);
+
+    Optional<ShortFormDetailResponse> selectShortFormDetail(Long shortFormId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -3,6 +3,7 @@ package com.innerpeace.themoonha.domain.lesson.service;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
 
 /**
  * 강좌 서비스 인터페이스
@@ -15,6 +16,7 @@ import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
  * ----------  --------    ---------------------------
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * </pre>
  */
 public interface LessonService {
@@ -22,4 +24,5 @@ public interface LessonService {
 
     LessonDetailResponse findLessonDetail(Long lessonId);
 
+    ShortFormDetailResponse findShortFormDetail(Long shortFormId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -3,6 +3,7 @@ package com.innerpeace.themoonha.domain.lesson.service;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
 import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
 import com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
  * ----------  --------    ---------------------------
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * </pre>
  */
 @Service
@@ -45,5 +47,11 @@ public class LessonServiceImpl implements LessonService {
     public LessonDetailResponse findLessonDetail(Long lessonId) {
         return lessonMapper.selectLessonDetail(lessonId)
                 .orElseThrow(() -> new CustomException(ErrorCode.LESSON_NOT_FOUND));
+    }
+
+    @Override
+    public ShortFormDetailResponse findShortFormDetail(Long shortFormId) {
+        return lessonMapper.selectShortFormDetail(shortFormId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SHORTFORM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     MEMBER_NOT_FOUND(404, "존재하지 않은 유저입니다."),
-    LESSON_NOT_FOUND(404, "강좌가 존재하지 않습니다.");
+    LESSON_NOT_FOUND(404, "강좌가 존재하지 않습니다."),
+    SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다.");
     private final int status;
     private final String message;
 

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -159,4 +159,26 @@
         where
             l.lesson_id = #{lessonId}
     </select>
+
+    <select id="selectShortFormDetail"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse">
+        select
+            l.lesson_id,
+            m.name tutor_name,
+            s.name short_form_name,
+            l.title lesson_title,
+            s.video_url
+        from
+            short_form s
+        join
+            lesson l
+        on
+            s.lesson_id = l.lesson_id
+        join
+            member m
+        on
+            l.member_id = m.member_id
+        where
+            s.short_form_id = #{shortFormId}
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
금주의 1분 강좌(숏폼) 상세 조회 API를 구현했습니다.

## ⭐️ 관련 이슈
- closes : #6 

## 📍 작업한 내용
- 금주의 1분 강좌(숏폼) 상세 조회 API 구현

## 🔎 결과 및 이슈 공유
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/d4277803-a37a-4e0e-92fd-a1461692da3f">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
