### PR TITLE
[CRAFT] [KAN-61] 문화공방 메인 페이지 조회 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,16 @@
             <artifactId>aspectjrt</artifactId>
             <version>${org.aspectj-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>${org.aspectj-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjtools</artifactId>
+            <version>${org.aspectj-version}</version>
+        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/controller/CraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/controller/CraftController.java
@@ -1,0 +1,30 @@
+package com.innerpeace.themoonha.domain.craft.controller;
+
+import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 문화공방 컨트롤러
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/craft")
+public class CraftController {
+    @GetMapping("/list")
+    public ResponseEntity<CraftMainResponse> craftMain() {
+
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/controller/CraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/controller/CraftController.java
@@ -1,6 +1,8 @@
 package com.innerpeace.themoonha.domain.craft.controller;
 
 import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
+import com.innerpeace.themoonha.domain.craft.service.CraftService;
+import com.innerpeace.themoonha.global.util.Criteria;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,8 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/craft")
 public class CraftController {
+    private final CraftService craftService;
     @GetMapping("/list")
-    public ResponseEntity<CraftMainResponse> craftMain() {
-
+    public ResponseEntity<CraftMainResponse> craftMain(Criteria criteria) {
+        return ResponseEntity.ok(craftService.findCraftMain(criteria));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/CraftMainResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/CraftMainResponse.java
@@ -2,12 +2,15 @@ package com.innerpeace.themoonha.domain.craft.dto;
 
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 문화공방 메인 페이지 응답 DTO
+ *
  * @author 손승완
- * @since 2024.08.25
  * @version 1.0
  *
  * <pre>
@@ -15,6 +18,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.25  	손승완       최초 생성
  * </pre>
+ * @since 2024.08.25
  */
 @Getter
 @AllArgsConstructor
@@ -26,4 +30,25 @@ public class CraftMainResponse {
     private List<WishLessonDTO> firstWishLessonList;
     private List<WishLessonDTO> secondWishLessonList;
     private List<SuggestionDTO> suggestionList;
+
+
+    public static CraftMainResponse of(List<PrologueDTO> prologueList,
+                                       List<WishLessonDTO> wishLessonList,
+                                       List<SuggestionDTO> suggestionList) {
+
+        Map<Boolean, List<PrologueDTO>> prologueMap = prologueList.stream()
+                .collect(Collectors.partitioningBy(prologueDTO -> prologueDTO.getType() == 1));
+
+        String theme = wishLessonList.get(0).getTheme();
+        Map<Boolean, List<WishLessonDTO>> wishLessonMap = wishLessonList.stream()
+                .collect(Collectors.partitioningBy(wishLessonDTO -> wishLessonDTO.getTheme().equals(theme)));
+
+        return CraftMainResponse.builder()
+                .firstPrologueList(prologueMap.get(true))
+                .secondPrologueList(prologueMap.get(false))
+                .firstWishLessonList(wishLessonMap.get(true))
+                .secondWishLessonList(wishLessonMap.get(false))
+                .suggestionList(suggestionList)
+                .build();
+    }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/CraftMainResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/CraftMainResponse.java
@@ -1,0 +1,29 @@
+package com.innerpeace.themoonha.domain.craft.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 문화공방 메인 페이지 응답 DTO
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class CraftMainResponse {
+    private List<PrologueDTO> firstPrologueList;
+    private List<PrologueDTO> secondPrologueList;
+    private List<WishLessonDTO> firstWishLessonList;
+    private List<WishLessonDTO> secondWishLessonList;
+    private List<SuggestionDTO> suggestionList;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/PrologueDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/PrologueDTO.java
@@ -11,4 +11,5 @@ public class PrologueDTO {
     private String title;
     private String thumbnailUrl;
     private int likeCnt;
+    private int type;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/PrologueDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/PrologueDTO.java
@@ -2,6 +2,18 @@ package com.innerpeace.themoonha.domain.craft.dto;
 
 import lombok.*;
 
+/**
+ * 문화공방 메인 페이지 프롤로그 DTO
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/PrologueDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/PrologueDTO.java
@@ -1,0 +1,14 @@
+package com.innerpeace.themoonha.domain.craft.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class PrologueDTO {
+    private Long prologueId;
+    private String title;
+    private String thumbnailUrl;
+    private int likeCnt;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/SuggestionDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/SuggestionDTO.java
@@ -1,10 +1,18 @@
 package com.innerpeace.themoonha.domain.craft.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+
+import java.util.Date;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class SuggestionDTO {
+    private String memberName;
+    private String memberProfileImgUrl;
+    private String content;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+    private Date createdAt;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/SuggestionDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/SuggestionDTO.java
@@ -1,0 +1,10 @@
+package com.innerpeace.themoonha.domain.craft.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class SuggestionDTO {
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/WishLessonDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/WishLessonDTO.java
@@ -1,0 +1,13 @@
+package com.innerpeace.themoonha.domain.craft.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class WishLessonDTO {
+    private Long wishLessonId;
+    private String title;
+    private int voteCnt;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/dto/WishLessonDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/dto/WishLessonDTO.java
@@ -10,4 +10,5 @@ public class WishLessonDTO {
     private Long wishLessonId;
     private String title;
     private int voteCnt;
+    private String theme;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.java
@@ -1,0 +1,11 @@
+package com.innerpeace.themoonha.domain.craft.mapper;
+
+import com.innerpeace.themoonha.domain.craft.dto.PrologueDTO;
+import com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO;
+
+import java.util.List;
+
+public interface CraftMapper {
+    List<PrologueDTO> selectPrologueList();
+    List<WishLessonDTO> selectWishLessonList();
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.java
@@ -7,6 +7,18 @@ import com.innerpeace.themoonha.global.util.Criteria;
 
 import java.util.List;
 
+/**
+ * 문화공방 매퍼
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
 public interface CraftMapper {
     List<PrologueDTO> selectPrologueList();
     List<WishLessonDTO> selectWishLessonList();

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.java
@@ -1,11 +1,15 @@
 package com.innerpeace.themoonha.domain.craft.mapper;
 
 import com.innerpeace.themoonha.domain.craft.dto.PrologueDTO;
+import com.innerpeace.themoonha.domain.craft.dto.SuggestionDTO;
 import com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO;
+import com.innerpeace.themoonha.global.util.Criteria;
 
 import java.util.List;
 
 public interface CraftMapper {
     List<PrologueDTO> selectPrologueList();
     List<WishLessonDTO> selectWishLessonList();
+
+    List<SuggestionDTO> selectSuggestionList(Criteria criteria);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftService.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.craft.service;
 
 import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
+import com.innerpeace.themoonha.global.util.Criteria;
 
 /**
  * 문화공방 서비스 인터페이스
@@ -15,5 +16,5 @@ import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
  * </pre>
  */
 public interface CraftService {
-    CraftMainResponse findCraftMain();
+    CraftMainResponse findCraftMain(Criteria criteria);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftService.java
@@ -1,0 +1,19 @@
+package com.innerpeace.themoonha.domain.craft.service;
+
+import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
+
+/**
+ * 문화공방 서비스 인터페이스
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
+public interface CraftService {
+    CraftMainResponse findCraftMain();
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftServiceImpl.java
@@ -2,8 +2,10 @@ package com.innerpeace.themoonha.domain.craft.service;
 
 import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
 import com.innerpeace.themoonha.domain.craft.dto.PrologueDTO;
+import com.innerpeace.themoonha.domain.craft.dto.SuggestionDTO;
 import com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO;
 import com.innerpeace.themoonha.domain.craft.mapper.CraftMapper;
+import com.innerpeace.themoonha.global.util.Criteria;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +31,7 @@ public class CraftServiceImpl implements CraftService {
 
     @Override
     @Transactional(readOnly = true)
-    public CraftMainResponse findCraftMain() {
+    public CraftMainResponse findCraftMain(Criteria criteria) {
         // 1. 프롤로그 목록 불러오기
         List<PrologueDTO> prologueList = craftMapper.selectPrologueList();
 
@@ -37,7 +39,8 @@ public class CraftServiceImpl implements CraftService {
         List<WishLessonDTO> wishLessonList = craftMapper.selectWishLessonList();
 
         // 3. 제안합니다 댓글 목록 불러오기
-//        craftMapper.selectSuggestionList();
+        List<SuggestionDTO> suggestionList = craftMapper.selectSuggestionList(criteria);
 
+        return CraftMainResponse.of(prologueList, wishLessonList, suggestionList);
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/craft/service/CraftServiceImpl.java
@@ -1,0 +1,43 @@
+package com.innerpeace.themoonha.domain.craft.service;
+
+import com.innerpeace.themoonha.domain.craft.dto.CraftMainResponse;
+import com.innerpeace.themoonha.domain.craft.dto.PrologueDTO;
+import com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO;
+import com.innerpeace.themoonha.domain.craft.mapper.CraftMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 문화공방 서비스 구현체
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
+@Service
+@RequiredArgsConstructor
+public class CraftServiceImpl implements CraftService {
+    private final CraftMapper craftMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public CraftMainResponse findCraftMain() {
+        // 1. 프롤로그 목록 불러오기
+        List<PrologueDTO> prologueList = craftMapper.selectPrologueList();
+
+        // 2. 듣고싶은 강좌 목록 불러오기
+        List<WishLessonDTO> wishLessonList = craftMapper.selectWishLessonList();
+
+        // 3. 제안합니다 댓글 목록 불러오기
+//        craftMapper.selectSuggestionList();
+
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/global/util/Criteria.java
+++ b/src/main/java/com/innerpeace/themoonha/global/util/Criteria.java
@@ -4,6 +4,18 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * 페이징 처리 클래스
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
 @Getter
 @Setter
 @ToString

--- a/src/main/java/com/innerpeace/themoonha/global/util/Criteria.java
+++ b/src/main/java/com/innerpeace/themoonha/global/util/Criteria.java
@@ -1,0 +1,23 @@
+package com.innerpeace.themoonha.global.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class Criteria {
+    private int pageNum;
+    private int size;
+    private static final int DEFAULT_PAGE_SIZE = 5;
+
+    public Criteria() {
+        this(1, DEFAULT_PAGE_SIZE);
+    }
+
+    public Criteria(int pageNum, int size) {
+        this.pageNum = pageNum;
+        this.size = size;
+    }
+}

--- a/src/main/resources/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.xml
@@ -17,12 +17,14 @@
 <mapper namespace="com.innerpeace.themoonha.domain.craft.mapper.CraftMapper">
 
 
-    <select id="selectPrologueList" resultType="com.innerpeace.themoonha.domain.craft.dto.PrologueDTO">
+    <select id="selectPrologueList"
+            resultType="com.innerpeace.themoonha.domain.craft.dto.PrologueDTO">
         select
             p.prologue_id,
             p.title,
             p.thumbnail_url,
-            count(l.like_cnt_id) like_cnt
+            count(l.like_cnt_id) like_cnt,
+            p.type
         from
             prologue p
         left join
@@ -36,11 +38,14 @@
         order by
             p.type
     </select>
-    <select id="selectWishLessonList" resultType="com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO">
+
+    <select id="selectWishLessonList"
+            resultType="com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO">
         select
             w.wish_lesson_id,
             w.title,
-            count(v.vote_id) vote_cnt
+            count(v.vote_id) vote_cnt,
+            w.theme
         from
             wish_lesson w
         left join
@@ -53,5 +58,35 @@
             w.wish_lesson_id, w.title, w.theme
         order by
             w.theme
+    </select>
+
+    <select id="selectSuggestionList"
+            resultType="com.innerpeace.themoonha.domain.craft.dto.SuggestionDTO">
+        <![CDATA[
+        select
+            member_name,
+            member_profile_img_url,
+            content,
+            created_at
+        from
+            (
+             select /*+INDEX_DESC(s pk_suggestion)*/
+                 rownum rn,
+                 m.name member_name,
+                 m.profile_img_url member_profile_img_url,
+                 s.content,
+                 s.created_at
+             from
+                 suggestion s
+             join
+                 member m
+             on
+                 s.member_id = m.member_id
+             where
+                 rownum <= #{pageNum} * #{size}
+            )
+        where
+            rn > (#{pageNum} - 1) * #{size}
+        ]]>
     </select>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/craft/mapper/CraftMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 문화공방 매퍼 XML
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ==========  =========    =========
+ * 2024.08.25  	손승완        최초 생성
+ * </pre>
+ -->
+<mapper namespace="com.innerpeace.themoonha.domain.craft.mapper.CraftMapper">
+
+
+    <select id="selectPrologueList" resultType="com.innerpeace.themoonha.domain.craft.dto.PrologueDTO">
+        select
+            p.prologue_id,
+            p.title,
+            p.thumbnail_url,
+            count(l.like_cnt_id) like_cnt
+        from
+            prologue p
+        left join
+            like_cnt l
+        on
+            p.prologue_id = l.prologue_id
+        where
+            p.deleted_at is null
+        group by
+            p.prologue_id, p.title, p.thumbnail_url, p.type
+        order by
+            p.type
+    </select>
+    <select id="selectWishLessonList" resultType="com.innerpeace.themoonha.domain.craft.dto.WishLessonDTO">
+        select
+            w.wish_lesson_id,
+            w.title,
+            count(v.vote_id) vote_cnt
+        from
+            wish_lesson w
+        left join
+            vote v
+        on
+            w.wish_lesson_id = v.wish_lesson_id
+        where
+            w.deleted_at is null
+        group by
+            w.wish_lesson_id, w.title, w.theme
+        order by
+            w.theme
+    </select>
+</mapper>


### PR DESCRIPTION
# 💡 PR 요약
문화공방 메인 페이지 조회 기능을 구현했습니다.

## ⭐️ 관련 이슈
- closes : #9 

## 📍 작업한 내용
- 문화공방 메인 페이지 조회 구현
- 제안합니다 댓글 목록 페이징 처리
- 프롤로그, 듣고 싶은 강좌 목록은 각각 두가지 목록으로 분류해서 응답

## 🔎 결과 및 이슈 공유
![image](https://github.com/user-attachments/assets/ba203837-0f95-43d5-80d7-15086593647a)
![image](https://github.com/user-attachments/assets/e6f34849-81aa-4ee5-b841-a2dbd98b77ad)
![image](https://github.com/user-attachments/assets/86a54b94-8f25-4535-83bc-7032ad7651fc)


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
