### PR TITLE
[AUTH] [KAN-11] 회원가입 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ build/
 .vscode/
 
 ### Mac OS ###
+.DS_Store
+**/.DS_Store
 .DS_Storeroot-context.xml
 root-context.xml

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,19 @@
             <version>2.12.3</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-web -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>5.7.3</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-config -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <version>5.7.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/controller/AuthController.java
@@ -5,13 +5,24 @@ import com.innerpeace.themoonha.domain.auth.service.AuthService;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 회원가입/로그인 컨트롤러
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
 @RestController
 @RequestMapping("/auth")
 @Slf4j

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.innerpeace.themoonha.domain.auth.controller;
+
+import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
+import com.innerpeace.themoonha.domain.auth.service.AuthService;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@Slf4j
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping(value="/signup")
+    public ResponseEntity<CommonResponse> signUp(@RequestBody SignUpRequest dto) {
+        return authService.signUp(dto) == 1 ?
+                ResponseEntity.ok(CommonResponse.from("회원가입 성공")) :
+                ResponseEntity.ok(CommonResponse.of(false, "회원가입 실패"));
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/dto/SignUpRequest.java
@@ -1,0 +1,20 @@
+package com.innerpeace.themoonha.domain.auth.dto;
+
+import com.innerpeace.themoonha.domain.auth.vo.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class SignUpRequest {
+    private String username;
+    private String password;
+    private String name;
+    private MemberRole memberRole;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/dto/SignUpRequest.java
@@ -7,6 +7,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * 회원가입 요청 dto
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.java
@@ -1,0 +1,12 @@
+package com.innerpeace.themoonha.domain.auth.mapper;
+
+import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
+import com.innerpeace.themoonha.global.entity.Member;
+import java.util.Optional;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AuthMapper {
+    int insertMember(Member member);
+    Optional<Member> selectMemberByUsername(String userName);
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.java
@@ -1,10 +1,21 @@
 package com.innerpeace.themoonha.domain.auth.mapper;
 
-import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
 import com.innerpeace.themoonha.global.entity.Member;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
+/**
+ * 회원가입/로그인 매퍼
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
 @Mapper
 public interface AuthMapper {
     int insertMember(Member member);

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.innerpeace.themoonha.domain.auth.service;
+
+import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
+
+public interface AuthService {
+    int signUp(SignUpRequest request);
+    boolean checkAvailableUsername(String userName);
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthService.java
@@ -2,6 +2,18 @@ package com.innerpeace.themoonha.domain.auth.service;
 
 import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
 
+/**
+ * 회원가입/로그인 서비스
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
 public interface AuthService {
     int signUp(SignUpRequest request);
     boolean checkAvailableUsername(String userName);

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthServiceImpl.java
@@ -2,7 +2,6 @@ package com.innerpeace.themoonha.domain.auth.service;
 
 import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
 import com.innerpeace.themoonha.domain.auth.mapper.AuthMapper;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
 import com.innerpeace.themoonha.global.entity.Member;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
@@ -11,6 +10,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+/**
+ * 회원가입/로그인 서비스 구현체
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,40 @@
+package com.innerpeace.themoonha.domain.auth.service;
+
+import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
+import com.innerpeace.themoonha.domain.auth.mapper.AuthMapper;
+import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
+import com.innerpeace.themoonha.global.entity.Member;
+import com.innerpeace.themoonha.global.exception.CustomException;
+import com.innerpeace.themoonha.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthServiceImpl implements AuthService{
+    private final AuthMapper authMapper;
+    private final PasswordEncoder encoder;
+
+    @Override
+    public int signUp(SignUpRequest request) {
+        if(!checkAvailableUsername(request.getUsername()))
+            throw new CustomException(ErrorCode.MEMBER_DUPLICATE);
+
+        // 비밀번호 암호화
+        String encodedPassword = encoder.encode(request.getPassword());
+
+        Member member = Member.of(request,encodedPassword);
+
+        int result = authMapper.insertMember(member);
+
+        return result;
+    }
+
+    @Override
+    public boolean checkAvailableUsername(String userName) {
+        return !authMapper.selectMemberByUsername(userName).isPresent();
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/vo/MemberRole.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/vo/MemberRole.java
@@ -1,0 +1,24 @@
+package com.innerpeace.themoonha.domain.auth.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberRole {
+    ADMIN(0,"ADMIN"),
+    MEMBER(1,"MEMBER"),
+    TUTOR(2,"TUTOR");
+
+    private final int num;
+    private final String role;
+
+    public static MemberRole fromNum(int num) {
+        for (MemberRole role : values()) {
+            if (role.getNum() == num) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("Invalid MemberRole number: " + num);
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/auth/vo/MemberRole.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/auth/vo/MemberRole.java
@@ -3,6 +3,18 @@ package com.innerpeace.themoonha.domain.auth.vo;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 회원 역할 enum
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @RequiredArgsConstructor
 public enum MemberRole {

--- a/src/main/java/com/innerpeace/themoonha/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/innerpeace/themoonha/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,26 @@
+package com.innerpeace.themoonha.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * PasswordEncoder 설정
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	최유경       최초 생성
+ * </pre>
+ */
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/global/dto/CommonResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/global/dto/CommonResponse.java
@@ -1,0 +1,27 @@
+package com.innerpeace.themoonha.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommonResponse {
+    private boolean success;
+    private String message;
+
+    public static CommonResponse from(String message){
+        return CommonResponse.builder()
+                .success(true)
+                .message(message)
+                .build();
+    }
+
+    public static CommonResponse of(boolean success, String message){
+        return CommonResponse.builder()
+                .success(success)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/global/entity/Member.java
+++ b/src/main/java/com/innerpeace/themoonha/global/entity/Member.java
@@ -1,0 +1,40 @@
+package com.innerpeace.themoonha.global.entity;
+
+import com.innerpeace.themoonha.domain.auth.dto.SignUpRequest;
+import com.innerpeace.themoonha.domain.auth.vo.MemberRole;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class Member {
+    private int memberId;
+    private String username;
+    private String password;
+    private String name;
+    private MemberRole memberRole;
+    private String profileImgUrl;
+    private String fcmToken;
+    private Date createdAt;
+    private Date deletedAt;
+
+    public static Member of(SignUpRequest request, String password){
+        return Member.builder()
+                .username(request.getUsername())
+                .password(password)
+                .name(request.getName())
+                .memberRole(request.getMemberRole())
+                .build();
+    }
+
+    public void setMemberRole(int memberRoleNum) {
+        this.memberRole = MemberRole.fromNum(memberRoleNum);
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
     MEMBER_NOT_FOUND(404, "존재하지 않은 유저입니다."),
     LESSON_NOT_FOUND(404, "강좌가 존재하지 않습니다."),
-    SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다.");
+    SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다."),
+    MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요.");
     private final int status;
     private final String message;
 

--- a/src/main/resources/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 회원 매퍼 XML
+ * @author 최유경
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ==========  =========    =========
+ * 2024.08.25  	손승완        최초 생성
+ * </pre>
+ -->
+<mapper namespace="com.innerpeace.themoonha.domain.auth.mapper.AuthMapper">
+
+    <insert id="insertMember" parameterType="com.innerpeace.themoonha.global.entity.Member">
+        <![CDATA[
+            insert into member (member_id, username, password, name, member_role, fcm_token)
+            values (member_seq.nextval, #{username}, #{password}, #{name}, #{memberRole.num}, '123')
+        ]]>
+    </insert>
+
+
+    <resultMap id="MemberResultMap" type="com.innerpeace.themoonha.global.entity.Member" autoMapping="true">
+        <result property="memberRole" column="member_role" javaType="int"/>
+    </resultMap>
+
+    <select id="selectMemberByUsername" resultType="com.innerpeace.themoonha.global.entity.Member">
+        <![CDATA[
+            select
+                member_id,
+                username,
+                password,
+                name,
+                member_role,
+                created_at,
+                deleted_at
+            from
+                member
+            where
+                username=#{username}
+        ]]>
+    </select>
+</mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/auth/mapper/AuthMapper.xml
@@ -11,7 +11,7 @@
  * <pre>
  * 수정일        	수정자        수정내용
  * ==========  =========    =========
- * 2024.08.25  	손승완        최초 생성
+ * 2024.08.25  	최유경        최초 생성
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.auth.mapper.AuthMapper">


### PR DESCRIPTION
# 💡 PR 요약
회원가입 API 구현했습니다. 

## ⭐️ 관련 이슈
- closes : #1 

## 📍 작업한 내용
- passwordEncoder 
- MemberRole Enum 작성
- 회원가입 API 구현

## 🔎 결과 및 이슈 공유
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/4ca7f4bb-de5f-4bbf-a0b0-c7e912ea45e2">

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/27b1cf93-954b-44db-8dd7-ce76960d9bf2">

프로필 이미지 미구현

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
