### PR TITLE
[LOUNGE] [KAN-27] 라운지 목록 조회 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
@@ -1,0 +1,44 @@
+package com.innerpeace.themoonha.domain.lounge.controller;
+
+import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+import com.innerpeace.themoonha.domain.lounge.service.LoungeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 라운지 컨트롤러
+ * @author 조희정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	조희정       최초 생성
+ * 2024.08.25  	조희정       loungeList 메서드 추가
+ * </pre>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/lounge")
+@Slf4j
+public class LoungeController {
+
+    private final LoungeService loungeService;
+
+    /**
+     * 라운지 목록 조회
+     * @return
+     */
+    @GetMapping("/list")
+    public ResponseEntity<List<LoungeListResponse>> loungeList() {
+        Long memberId = 1L; // 임시 memberId
+        return ResponseEntity.ok(loungeService.findLoungeList(memberId));
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeListResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeListResponse.java
@@ -1,0 +1,35 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import com.innerpeace.themoonha.global.util.DateTimeUtil;
+import lombok.*;
+
+/**
+ * 라운지 목록 응답 DTO
+ * @author 조희정
+ * @since 2024.08.24
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	조희정       최초 생성
+ * 2024.08.26  	조희정       DateTimeUtil 적용
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungeListResponse {
+
+    private Long loungeId;
+    private String title;
+    private String loungeImgUrl;
+    private String latestPostTime;
+
+    public void setLatestPostTime(String latestPostTime) {
+        this.latestPostTime = DateTimeUtil.timeAgo(latestPostTime);
+    }
+
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
@@ -1,0 +1,28 @@
+package com.innerpeace.themoonha.domain.lounge.mapper;
+
+import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 라운지 매퍼
+ * @author 조희정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	조희정       최초 생성
+ * 2024.08.25  	조희정       selectLoungeList 메서드 추가
+ * </pre>
+ */
+public interface LoungeMapper {
+    /**
+     * 라운지 목록 조회
+     * @param memberId
+     * @return
+     */
+    List<LoungeListResponse> selectLoungeList(Long memberId);
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
@@ -1,0 +1,27 @@
+package com.innerpeace.themoonha.domain.lounge.service;
+
+import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+
+import java.util.List;
+
+/**
+ * 라운지 서비스 인터페이스
+ * @author 조희정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	조희정       최초 생성
+ * 2024.08.25  	조희정       findLoungeList 메서드 추가
+ * </pre>
+ */
+public interface LoungeService {
+    /**
+     * 라운지 목록 조회
+     * @param memberId
+     * @return
+     */
+    List<LoungeListResponse> findLoungeList(Long memberId);
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -1,0 +1,40 @@
+package com.innerpeace.themoonha.domain.lounge.service;
+
+import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+import com.innerpeace.themoonha.domain.lounge.mapper.LoungeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 라운지 서비스 구현체
+ * @author 조희정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	조희정       최초 생성
+ * 2024.08.25  	조희정       findLoungeList 메서드 추가
+ * </pre>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoungeServiceImpl implements LoungeService {
+
+    private final LoungeMapper loungeMapper;
+
+    /**
+     * 라운지 목록 조회
+     * @param memberId
+     * @return
+     */
+    @Override
+    public List<LoungeListResponse> findLoungeList(Long memberId) {
+        return loungeMapper.selectLoungeList(memberId);
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
+++ b/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
@@ -1,0 +1,59 @@
+package com.innerpeace.themoonha.global.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+/**
+ * 시간 포맷 유틸리티
+ * @author 조희정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	조희정       최초 생성
+ * </pre>
+ */
+public class DateTimeUtil {
+
+    public static String timeAgo(String timeString) {
+        if (timeString == null) {
+            return "";
+        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime timeObj = LocalDateTime.parse(timeString, formatter);
+        LocalDateTime now = LocalDateTime.now();
+
+        Duration duration = Duration.between(timeObj, now);
+
+        // 오늘 이전이라면 날짜 그대로 반환
+        if (timeObj.toLocalDate().isBefore(now.toLocalDate())) {
+            return formatDate(timeObj);
+        }
+
+        // 오늘이라면 날짜 포맷
+        long seconds = duration.getSeconds();
+
+        if (seconds < 60) {
+            return seconds + "초 전";
+        } else if (seconds < 3600) {
+            long minutes = seconds / 60;
+            return minutes + "분 전";
+        } else if (seconds < 86400) {
+            long hours = seconds / 3600;
+            return hours + "시간 전";
+        } else {
+            return formatDate(timeObj);
+        }
+    }
+
+    private static String formatDate(LocalDateTime time) {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a hh시 mm분", Locale.KOREAN);
+        return time.format(dateFormatter).replace("AM", "오전").replace("PM", "오후");
+    }
+}
+

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -23,31 +23,23 @@
             lo.lounge_id,
             le.title,
             lo.lounge_img_url,
-            max(lp.created_at) AS latest_post_time
+            lp.created_at AS latest_post_time
         FROM
             sugang s
-                JOIN
-            member m
-            ON m.member_id = s.member_id
-                JOIN
-            lounge lo
-            ON lo.lesson_id = s.lesson_id
-                JOIN
-            lesson le
-            on s.lesson_id = le.lesson_id
-                LEFT JOIN
-            lounge_post lp
-            ON lo.lounge_id = lp.lounge_id
+                JOIN member m ON m.member_id = s.member_id
+                JOIN lounge lo ON lo.lesson_id = s.lesson_id
+                JOIN lesson le ON s.lesson_id = le.lesson_id
+                LEFT JOIN lounge_post lp ON lo.lounge_id = lp.lounge_id
+                AND lp.created_at = (
+                    SELECT /*+ INDEX_DESC(lp PK_LOUNGE_POST) */
+                        MAX(created_at)
+                    FROM lounge_post
+                    WHERE lounge_id = lo.lounge_id
+                )
         WHERE
             m.member_id = #{memberId}
           AND s.online_yn = 0
           AND s.lounge_yn = 1
-        GROUP BY
-            lo.lounge_id,
-            le.title,
-            lo.lounge_img_url
-        ORDER BY
-            MAX(lp.created_at) DESC
     </select>
 
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 라운지 매퍼 XML
+ * @author 조희정
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ==========  =========    =========
+ * 2024.08.25  	조희정        최초 생성
+ * 2024.08.25  	조희정        selectLoungeList 쿼리 추가
+ * </pre>
+ -->
+<mapper namespace="com.innerpeace.themoonha.domain.lounge.mapper.LoungeMapper">
+
+    <select id="selectLoungeList"
+            resultType="com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse">
+        SELECT
+            lo.lounge_id,
+            le.title,
+            lo.lounge_img_url,
+            max(lp.created_at) AS latest_post_time
+        FROM
+            sugang s
+                JOIN
+            member m
+            ON m.member_id = s.member_id
+                JOIN
+            lounge lo
+            ON lo.lesson_id = s.lesson_id
+                JOIN
+            lesson le
+            on s.lesson_id = le.lesson_id
+                LEFT JOIN
+            lounge_post lp
+            ON lo.lounge_id = lp.lounge_id
+        WHERE
+            m.member_id = #{memberId}
+          AND s.online_yn = 0
+          AND s.lounge_yn = 1
+        GROUP BY
+            lo.lounge_id,
+            le.title,
+            lo.lounge_img_url
+        ORDER BY
+            MAX(lp.created_at) DESC
+    </select>
+
+</mapper>


### PR DESCRIPTION
# 💡 PR 요약
라운지 목록 조회 구현했습니다.

## ⭐️ 관련 이슈
- closes : #7 

## 📍 작업한 내용
- 라운지 목록 조회 구현

## 🔎 결과 및 이슈 공유
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/63d22327-3e67-4436-8cb3-93664d060e0c">



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
