### PR TITLE
[LESSON] [KAN-24] 강사 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -1,9 +1,6 @@
 package com.innerpeace.themoonha.domain.lesson.controller;
 
-import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.*;
 import com.innerpeace.themoonha.domain.lesson.service.LessonService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
+ * 2024.08.26   손승완       강사 상세보기 기능 추가
  * </pre>
  */
 @RestController
@@ -65,5 +63,10 @@ public class LessonController {
     @GetMapping("/shortform/{shortFormId}")
     public ResponseEntity<ShortFormDetailResponse> shortFormDetail(@PathVariable Long shortFormId) {
         return ResponseEntity.ok(lessonService.findShortFormDetail(shortFormId));
+    }
+
+    @GetMapping("/tutor/{tutorId}")
+    public ResponseEntity<TutorDetailResponse> tutorDetail(@PathVariable Long tutorId) {
+        return ResponseEntity.ok(lessonService.findTutorDetail(tutorId));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/TutorDetailResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/TutorDetailResponse.java
@@ -1,0 +1,56 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 강사 상세정보 조회 응답 DTO
+ * @author 손승완
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class TutorDetailResponse {
+    private String name;
+    private String profileImgUrl;
+    private List<String> endedLessonList;
+    private List<TutorLessonDetailDTO> ongoingLessonList;
+
+    public static TutorDetailResponse from(List<TutorLessonDetailDTO> tutorDetailList) {
+        List<String> endedLessonList = new ArrayList<>();
+        List<TutorLessonDetailDTO> ongoingLessonList = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate currentDate = LocalDate.now();
+
+        for (TutorLessonDetailDTO tutorDetailDTO : tutorDetailList) {
+            LocalDate lessonEndDate = LocalDate.parse(tutorDetailDTO.getEndDate(), formatter);
+            if (lessonEndDate.isBefore(currentDate)) {
+                String title = "[" + tutorDetailDTO.getEndDate() + "] " + tutorDetailDTO.getTitle();
+                endedLessonList.add(title);
+                continue;
+            }
+            ongoingLessonList.add(tutorDetailDTO);
+        }
+
+        return TutorDetailResponse.builder()
+                .name(tutorDetailList.get(0).getName())
+                .profileImgUrl(tutorDetailList.get(0).getProfileImgUrl())
+                .endedLessonList(endedLessonList)
+                .ongoingLessonList(ongoingLessonList)
+                .build();
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/TutorLessonDetailDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/TutorLessonDetailDTO.java
@@ -2,34 +2,30 @@ package com.innerpeace.themoonha.domain.lesson.dto;
 
 import lombok.*;
 
-
 /**
- * 강좌 목록 내부 강좌 정보 DTO
+ * 강사 상세정보 진행중인 강좌 정보 DTO
  * @author 손승완
- * @since 2024.08.24
+ * @since 2024.08.26
  * @version 1.0
  *
  * <pre>
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
- * 2024.08.24  	손승완       최초 생성
- * 2024.08.26   손승완       강좌 종료 날짜 필드 추가
+ * 2024.08.26  	손승완       최초 생성
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
-public class LessonDTO {
+public class TutorLessonDetailDTO {
+    private String name;
+    private String profileImgUrl;
     private Long lessonId;
-    private String thumbnailUrl;
-    private String target;
     private String title;
+    private String thumbnailUrl;
     private int cnt;
-    private int cost;
-    private String tutorName;
-    private String lessonTime;
     private String endDate;
+    private String lessonTime;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -1,10 +1,8 @@
 package com.innerpeace.themoonha.domain.lesson.mapper;
 
-import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.*;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -18,12 +16,12 @@ import java.util.Optional;
  * ----------  --------    ---------------------------
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
+ * 2024.08.26   손승완       강사 상세보기 기능 추가
  * </pre>
  */
 public interface LessonMapper {
     Optional<LessonListResponse> selectLessonList(LessonListRequest lessonListRequest);
-
     Optional<LessonDetailResponse> selectLessonDetail(Long lessonId);
-
     Optional<ShortFormDetailResponse> selectShortFormDetail(Long shortFormId);
+    List<TutorLessonDetailDTO> findTutorDetail(Long tutorId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -1,9 +1,6 @@
 package com.innerpeace.themoonha.domain.lesson.service;
 
-import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.*;
 
 /**
  * 강좌 서비스 인터페이스
@@ -17,6 +14,7 @@ import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
+ * 2024.08.26   손승완       강사 상세보기 기능 추가
  * </pre>
  */
 public interface LessonService {
@@ -25,4 +23,6 @@ public interface LessonService {
     LessonDetailResponse findLessonDetail(Long lessonId);
 
     ShortFormDetailResponse findShortFormDetail(Long shortFormId);
+
+    TutorDetailResponse findTutorDetail(Long tutorId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -1,9 +1,6 @@
 package com.innerpeace.themoonha.domain.lesson.service;
 
-import com.innerpeace.themoonha.domain.lesson.dto.LessonDetailResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest;
-import com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse;
-import com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse;
+import com.innerpeace.themoonha.domain.lesson.dto.*;
 import com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
@@ -11,10 +8,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 강좌 서비스 구현체
+ *
  * @author 손승완
- * @since 2024.08.24
  * @version 1.0
  *
  * <pre>
@@ -23,7 +23,9 @@ import org.springframework.stereotype.Service;
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
+ * 2024.08.26   손승완       강사 상세보기 기능 추가
  * </pre>
+ * @since 2024.08.24
  */
 @Service
 @RequiredArgsConstructor
@@ -54,4 +56,15 @@ public class LessonServiceImpl implements LessonService {
         return lessonMapper.selectShortFormDetail(shortFormId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SHORTFORM_NOT_FOUND));
     }
+
+    @Override
+    public TutorDetailResponse findTutorDetail(Long tutorId) {
+        List<TutorLessonDetailDTO> tutorDetailList = Optional
+                .ofNullable(lessonMapper.findTutorDetail(tutorId))
+                .filter(list -> !list.isEmpty())
+                .orElseThrow(() -> new CustomException(ErrorCode.TUTOR_NOT_FOUND));
+
+        return TutorDetailResponse.from(tutorDetailList);
+    }
+
 }

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -9,7 +9,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(404, "존재하지 않은 유저입니다."),
     LESSON_NOT_FOUND(404, "강좌가 존재하지 않습니다."),
     SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다."),
-    MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요.");
+    MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요."),
+    TUTOR_NOT_FOUND(404, "강사가 존재하지 않습니다");
     private final int status;
     private final String message;
 

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -13,6 +13,7 @@
  * ==========  =========    =========
  * 2024.08.24  	손승완        최초 생성
  * 2024.08.25   손승완        강좌 상세 조회 쿼리 추가
+ * 2024.08.26   손승완        강사 상세 조회 쿼리 추가
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
@@ -180,5 +181,29 @@
             l.member_id = m.member_id
         where
             s.short_form_id = #{shortFormId}
+    </select>
+
+    <select id="findTutorDetail"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.TutorLessonDetailDTO">
+
+        select
+            m.name,
+            m.profile_img_url,
+            l.lesson_id,
+            l.title,
+            l.thumbnail_url,
+            l.cnt,
+            l.end_date,
+            CASE
+                WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time END AS lesson_time
+        from
+            member m
+        join
+            lesson l
+        on
+            m.member_id = l.member_id
+        where
+            m.member_id = #{tutorId}
     </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
강사 상세 정보 조회 API를 구현했습니다.
코드가 지저분합니다..

## ⭐️ 관련 이슈
- closes : #17 

## 📍 작업한 내용
- 강사 상세 정보 조회 API 구현

## 🔎 결과 및 이슈 공유
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/6c7963d0-a441-44fd-b2e2-d0d44c61ab6f">



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
