### PR TITLE
[LESSON] [KAN-26] 장바구니 조회 및 담기 기능 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -2,13 +2,11 @@ package com.innerpeace.themoonha.domain.lesson.controller;
 
 import com.innerpeace.themoonha.domain.lesson.dto.*;
 import com.innerpeace.themoonha.domain.lesson.service.LessonService;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,7 +23,7 @@ import java.util.List;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 조회 기능 추가
+ * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
  * @since 2024.08.24
  */
@@ -78,6 +76,13 @@ public class LessonController {
     public ResponseEntity<List<CartResponse>> cartList() {
         Long memberId = 1L;
         return ResponseEntity.ok(lessonService.findCartList(memberId));
+    }
+
+    @PostMapping("/cart")
+    public ResponseEntity<CommonResponse> cartSave(@RequestBody CartRequest cartRequest) {
+        Long memberId = 1L;
+        cartRequest.setMemberId(memberId);
+        return ResponseEntity.ok(lessonService.addCart(cartRequest));
     }
 
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -10,10 +10,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 /**
  * 강좌 컨트롤러
+ *
  * @author 손승완
- * @since 2024.08.24
  * @version 1.0
  *
  * <pre>
@@ -23,7 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
+ * 2024.08.26   손승완       장바구니 조회 기능 추가
  * </pre>
+ * @since 2024.08.24
  */
 @RestController
 @RequiredArgsConstructor
@@ -69,4 +73,11 @@ public class LessonController {
     public ResponseEntity<TutorDetailResponse> tutorDetail(@PathVariable Long tutorId) {
         return ResponseEntity.ok(lessonService.findTutorDetail(tutorId));
     }
+
+    @GetMapping("/cart")
+    public ResponseEntity<List<CartResponse>> cartList() {
+        Long memberId = 1L;
+        return ResponseEntity.ok(lessonService.findCartList(memberId));
+    }
+
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -14,6 +14,7 @@ import java.util.List;
  * 강좌 컨트롤러
  *
  * @author 손승완
+ * @since 2024.08.24
  * @version 1.0
  *
  * <pre>
@@ -25,7 +26,6 @@ import java.util.List;
  * 2024.08.26   손승완       강사 상세보기 기능 추가
  * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
- * @since 2024.08.24
  */
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/CartRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/CartRequest.java
@@ -1,0 +1,25 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.*;
+
+/**
+ * 장바구니 담기 요청 DTO
+ * @author 손승완
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartRequest {
+    private Long lessonId;
+    private Long memberId;
+    private boolean onlineYn;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/CartResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/CartResponse.java
@@ -1,0 +1,36 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+
+/**
+ * 장바구니 응답 DTO
+ * @author 손승완
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26   손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartResponse {
+    private String branchName;
+    private String cartId;
+    private String lessonTitle;
+    private String period;
+    private String lessonTime;
+    private String tutorName;
+    private String target;
+    private int cost;
+    private Integer onlineCost;
+    private boolean onlineYn;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 조회 기능 추가
+ * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
  */
 public interface LessonMapper {
@@ -25,6 +25,7 @@ public interface LessonMapper {
     Optional<LessonDetailResponse> selectLessonDetail(Long lessonId);
     Optional<ShortFormDetailResponse> selectShortFormDetail(Long shortFormId);
     List<TutorLessonDetailDTO> selectTutorDetail(Long tutorId);
-
     List<CartResponse> selectCartList(Long memberId);
+    int insertCart(CartRequest cartRequest);
+
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -17,11 +17,14 @@ import java.util.Optional;
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
+ * 2024.08.26   손승완       장바구니 조회 기능 추가
  * </pre>
  */
 public interface LessonMapper {
     Optional<LessonListResponse> selectLessonList(LessonListRequest lessonListRequest);
     Optional<LessonDetailResponse> selectLessonDetail(Long lessonId);
     Optional<ShortFormDetailResponse> selectShortFormDetail(Long shortFormId);
-    List<TutorLessonDetailDTO> findTutorDetail(Long tutorId);
+    List<TutorLessonDetailDTO> selectTutorDetail(Long tutorId);
+
+    List<CartResponse> selectCartList(Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -2,6 +2,8 @@ package com.innerpeace.themoonha.domain.lesson.service;
 
 import com.innerpeace.themoonha.domain.lesson.dto.*;
 
+import java.util.List;
+
 /**
  * 강좌 서비스 인터페이스
  * @author 손승완
@@ -15,6 +17,7 @@ import com.innerpeace.themoonha.domain.lesson.dto.*;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
+ * 2024.08.26   손승완       장바구니 조회 기능 추가
  * </pre>
  */
 public interface LessonService {
@@ -25,4 +28,6 @@ public interface LessonService {
     ShortFormDetailResponse findShortFormDetail(Long shortFormId);
 
     TutorDetailResponse findTutorDetail(Long tutorId);
+
+    List<CartResponse> findCartList(Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.lesson.service;
 
 import com.innerpeace.themoonha.domain.lesson.dto.*;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
 
 import java.util.List;
 
@@ -17,7 +18,7 @@ import java.util.List;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 조회 기능 추가
+ * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
  */
 public interface LessonService {
@@ -30,4 +31,6 @@ public interface LessonService {
     TutorDetailResponse findTutorDetail(Long tutorId);
 
     List<CartResponse> findCartList(Long memberId);
+
+    CommonResponse addCart(CartRequest cartRequest);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -5,6 +5,7 @@ import com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
+import com.innerpeace.themoonha.global.vo.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -79,7 +80,7 @@ public class LessonServiceImpl implements LessonService {
     @Transactional
     public CommonResponse addCart(CartRequest cartRequest) {
         if (lessonMapper.insertCart(cartRequest) == 1) {
-            return new CommonResponse(true, "강좌가 성공적으로 장바구니에 담겼습니다.");
+            return CommonResponse.of(true, SuccessCode.CART_LESSON_ADDED_SUCCESS.getMessage());
         }
 
         throw new CustomException(ErrorCode.CART_LESSON_ALREADY_EXISTS);

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Optional;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
+ * 2024.08.26   손승완       장바구니 조회 기능 추가
  * </pre>
  * @since 2024.08.24
  */
@@ -60,11 +61,16 @@ public class LessonServiceImpl implements LessonService {
     @Override
     public TutorDetailResponse findTutorDetail(Long tutorId) {
         List<TutorLessonDetailDTO> tutorDetailList = Optional
-                .ofNullable(lessonMapper.findTutorDetail(tutorId))
+                .ofNullable(lessonMapper.selectTutorDetail(tutorId))
                 .filter(list -> !list.isEmpty())
                 .orElseThrow(() -> new CustomException(ErrorCode.TUTOR_NOT_FOUND));
 
         return TutorDetailResponse.from(tutorDetailList);
+    }
+
+    @Override
+    public List<CartResponse> findCartList(Long memberId) {
+        return lessonMapper.selectCartList(memberId);
     }
 
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -2,11 +2,13 @@ package com.innerpeace.themoonha.domain.lesson.service;
 
 import com.innerpeace.themoonha.domain.lesson.dto.*;
 import com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +26,7 @@ import java.util.Optional;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 조회 기능 추가
+ * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
  * @since 2024.08.24
  */
@@ -73,4 +75,13 @@ public class LessonServiceImpl implements LessonService {
         return lessonMapper.selectCartList(memberId);
     }
 
+    @Override
+    @Transactional
+    public CommonResponse addCart(CartRequest cartRequest) {
+        if (lessonMapper.insertCart(cartRequest) == 1) {
+            return new CommonResponse(true, "강좌가 성공적으로 장바구니에 담겼습니다.");
+        }
+
+        throw new CustomException(ErrorCode.CART_LESSON_ALREADY_EXISTS);
+    }
 }

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     LESSON_NOT_FOUND(404, "강좌가 존재하지 않습니다."),
     SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다."),
     MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요."),
-    TUTOR_NOT_FOUND(404, "강사가 존재하지 않습니다");
+    TUTOR_NOT_FOUND(404, "강사가 존재하지 않습니다"),
+    CART_LESSON_ALREADY_EXISTS(409, "강좌가 이미 장바구니에 담겨있습니다.");
     private final int status;
     private final String message;
 

--- a/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
@@ -1,0 +1,12 @@
+package com.innerpeace.themoonha.global.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+    CART_LESSON_ADDED_SUCCESS(200, "강좌가 성고적으로 장바구니에 담겼습니다");
+    private final int status;
+    private final String message;
+}

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -220,6 +220,7 @@
             case
                 when l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
                 else '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time end as lesson_time,
+            m.name tutor_name,
             l.target,
             l.cost,
             l.online_cost,

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -14,7 +14,7 @@
  * 2024.08.24  	손승완        최초 생성
  * 2024.08.25   손승완        강좌 상세 조회 쿼리 추가
  * 2024.08.26   손승완        강사 상세 조회 쿼리 추가
- * 2024.08.26   손승완        장바구니 조회 쿼리 추가
+ * 2024.08.26   손승완        장바구니 쿼리 추가
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
@@ -241,4 +241,20 @@
         where
             m.member_id = 1
     </select>
+
+    <insert id="insertCart">
+        insert into
+            cart (cart_id, member_id, lesson_id, online_yn)
+        select
+            cart_seq.nextval, #{memberId}, #{lessonId}, #{onlineYn}
+        from
+            dual
+        where
+            not exists (
+                    select 1
+                    from cart
+                    where lesson_id = #{lessonId}
+                      and member_id = #{memberId}
+            )
+    </insert>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -14,6 +14,7 @@
  * 2024.08.24  	손승완        최초 생성
  * 2024.08.25   손승완        강좌 상세 조회 쿼리 추가
  * 2024.08.26   손승완        강사 상세 조회 쿼리 추가
+ * 2024.08.26   손승완        장바구니 조회 쿼리 추가
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
@@ -164,6 +165,7 @@
     <select id="selectShortFormDetail"
             resultType="com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse">
         select
+
             l.lesson_id,
             m.name tutor_name,
             s.name short_form_name,
@@ -181,9 +183,11 @@
             l.member_id = m.member_id
         where
             s.short_form_id = #{shortFormId}
+        order by
+            b.branch_id
     </select>
 
-    <select id="findTutorDetail"
+    <select id="selectTutorDetail"
             resultType="com.innerpeace.themoonha.domain.lesson.dto.TutorLessonDetailDTO">
 
         select
@@ -205,5 +209,36 @@
             m.member_id = l.member_id
         where
             m.member_id = #{tutorId}
+    </select>
+    <select id="selectCartList"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.CartResponse">
+        select
+            b.name branch_name,
+            c.cart_id,
+            l.title lesson_title,
+            l.start_date || '~' || l.end_date period,
+            case
+                when l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                else '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time end as lesson_time,
+            l.target,
+            l.cost,
+            l.online_cost,
+            online_yn
+        from
+            member m
+        join
+            cart c
+        on
+            m.member_id = c.member_id
+        join
+            lesson l
+        on
+            c.lesson_id = l.lesson_id
+        join
+            branch b
+        on
+            l.branch_id = b.branch_id
+        where
+            m.member_id = 1
     </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
장바구니 조회 및 담기 기능을 구현했습니다.

## ⭐️ 관련 이슈
- closes : #20 

## 📍 작업한 내용
- 장바구니 조회
- 장바구니 담기(중복 담기 불가능)

## 🔎 결과 및 이슈 공유
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/cff1878f-38e0-498f-958e-75b6113596fd">
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/19d88634-ecec-48bf-a8c2-58b50e4ca497">
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/a4954eb6-d3b0-40a6-b323-297c9dec38ed">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
