### PR TITLE
[LOUNGE] [KAN-28] 라운지 홈 조회 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.Optional;
  * 2024.08.26   손승완       강사 상세보기 기능 추가
  * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
+ * @since 2024.08.24
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Optional;
  * 강좌 서비스 구현체
  *
  * @author 손승완
+ * @since 2024.08.24
  * @version 1.0
  *
  * <pre>
@@ -29,7 +30,6 @@ import java.util.Optional;
  * 2024.08.26   손승완       강사 상세보기 기능 추가
  * 2024.08.26   손승완       장바구니 기능 추가
  * </pre>
- * @since 2024.08.24
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
@@ -1,11 +1,12 @@
 package com.innerpeace.themoonha.domain.lounge.controller;
 
-import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+import com.innerpeace.themoonha.domain.lounge.dto.*;
 import com.innerpeace.themoonha.domain.lounge.service.LoungeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       loungeList 메서드 추가
+ * 2024.08.26  	조희정       loungeHome 메서드 추가
  * </pre>
  */
 @RestController
@@ -40,5 +42,17 @@ public class LoungeController {
     public ResponseEntity<List<LoungeListResponse>> loungeList() {
         Long memberId = 1L; // 임시 memberId
         return ResponseEntity.ok(loungeService.findLoungeList(memberId));
+    }
+
+    /**
+     * 라운지 홈 조회
+     * @param loungeId
+     * @return
+     */
+    @GetMapping("/{loungeId}/home")
+    public ResponseEntity<LoungeHomeResponse> loungeHome(@PathVariable Long loungeId) {
+        Long memberId = 1L; // 임시 memberId
+        String role = "ROLE_TUTOR"; // 임시 role
+        return ResponseEntity.ok(loungeService.findLoungeHome(loungeId, memberId, role));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceDTO.java
@@ -18,7 +18,6 @@ import java.util.List;
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceDTO.java
@@ -1,0 +1,35 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import com.innerpeace.themoonha.global.util.DateTimeUtil;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 수강생 출석 정보 DTO
+ * @author 조희정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceDTO {
+
+    private Long memberId;
+    private String name;
+    private String attendanceDate;
+    private Boolean attendanceYn;
+
+    public void setAttendanceDate(String attendanceDate) {
+        this.attendanceDate = attendanceDate.split(" ")[0];
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
@@ -1,0 +1,49 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 라운지 홈 응답 DTO
+ * @author 조희정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungeHomeResponse {
+
+    private LoungeInfoDTO loungeInfo;
+    private List<LoungePostDTO> loungeNoticePostList;
+    private List<LoungePostDTO> loungePostList;
+    private List<AttendanceDTO> attendanceList;
+    private List<LoungeMemberDTO> loungeMemberList;
+
+    public static LoungeHomeResponse of(LoungeInfoDTO loungeInfo,List<LoungePostDTO> loungePostList,
+                                        List<AttendanceDTO> attendanceList, List<LoungeMemberDTO> loungeMemberList) {
+
+        List<LoungePostDTO> loungeNoticePostList = loungePostList.stream()
+                .filter(LoungePostDTO::isNoticeYn)
+                .collect(Collectors.toList());
+
+        return LoungeHomeResponse.builder()
+                .loungeInfo(loungeInfo)
+                .loungeNoticePostList(loungeNoticePostList)
+                .loungePostList(loungePostList)
+                .attendanceList(attendanceList)
+                .loungeMemberList(loungeMemberList)
+                .build();
+    }
+
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
@@ -1,0 +1,29 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.*;
+
+/**
+ * 라운지 기본 정보 DTO
+ * @author 조희정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungeInfoDTO {
+    private Long lessonId;
+    private String title;
+    private String loungeImgUrl;
+    private Long tutorId;
+    private String tutorName;
+    private String summary;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
@@ -15,7 +15,6 @@ import lombok.*;
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeListResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeListResponse.java
@@ -6,7 +6,7 @@ import lombok.*;
 /**
  * 라운지 목록 응답 DTO
  * @author 조희정
- * @since 2024.08.24
+ * @since 2024.08.25
  * @version 1.0
  *
  * <pre>

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeListResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeListResponse.java
@@ -17,7 +17,6 @@ import lombok.*;
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeMemberDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeMemberDTO.java
@@ -1,0 +1,26 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.*;
+
+/**
+ * 라운지 회원 목록 DTO
+ * @author 조희정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungeMemberDTO {
+    private Long memberId;
+    private String name;
+    private String profileImgUrl;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeMemberDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeMemberDTO.java
@@ -15,7 +15,6 @@ import lombok.*;
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostDTO.java
@@ -18,7 +18,6 @@ import java.util.List;
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostDTO.java
@@ -1,0 +1,41 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import com.innerpeace.themoonha.global.util.DateTimeUtil;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 라운지 홈 게시글 정보 DTO
+ * @author 조희정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungePostDTO {
+
+    // 게시글 정보
+    private Long loungePostId;
+    private String content;
+    private boolean noticeYn;
+    private List<String> loungePostImgList;
+    private String createdAt;
+
+    // 작성자 정보
+    private LoungeMemberDTO loungeMember;
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = DateTimeUtil.timeAgo(createdAt);
+    }
+
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.lounge.mapper;
 
-import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+import com.innerpeace.themoonha.domain.lounge.dto.*;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +16,8 @@ import java.util.Optional;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.25  	조희정       최초 생성
- * 2024.08.25  	조희정       selectLoungeList 메서드 추가
+ * 2024.08.25  	조희정       selectLoungeList 메서드 생성
+ * 2024.08.26  	조희정       selectLoungeInfo, selectLoungePostList, selectAttendanceList, selectLoungeMemberList 메서드 생성
  * </pre>
  */
 public interface LoungeMapper {
@@ -25,4 +27,36 @@ public interface LoungeMapper {
      * @return
      */
     List<LoungeListResponse> selectLoungeList(Long memberId);
+
+    /**
+     * 라운지 기본 정보 조회
+     * @param loungeId
+     * @return
+     */
+    Optional<LoungeInfoDTO> selectLoungeInfo(Long loungeId);
+
+    /**
+     * 라운지 게시글 목록 조회
+     * @param loungeId
+     * @return
+     */
+    List<LoungePostDTO> selectLoungePostList(Long loungeId);
+
+    /**
+     * 수강생 출석 정보 조회
+     * @param loungeId
+     * @param memberId
+     * @param role
+     * @return
+     */
+    List<AttendanceDTO> selectAttendanceList(@Param("loungeId") Long loungeId,
+                                             @Param("memberId") Long memberId,
+                                             @Param("role") String role);
+
+    /**
+     * 라운지 회원 목록 조회
+     * @param loungeId
+     * @return
+     */
+    List<LoungeMemberDTO> selectLoungeMemberList(Long loungeId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
@@ -1,6 +1,6 @@
 package com.innerpeace.themoonha.domain.lounge.service;
 
-import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+import com.innerpeace.themoonha.domain.lounge.dto.*;
 
 import java.util.List;
 
@@ -15,6 +15,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       findLoungeList 메서드 추가
+ * 2024.08.26  	조희정       findLoungeHome 메서드 추가
  * </pre>
  */
 public interface LoungeService {
@@ -24,4 +25,13 @@ public interface LoungeService {
      * @return
      */
     List<LoungeListResponse> findLoungeList(Long memberId);
+
+    /**
+     * 라운지 홈 조회
+     * @param loungeId
+     * @param memberId
+     * @param role
+     * @return
+     */
+    LoungeHomeResponse findLoungeHome(Long loungeId, Long memberId, String role);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -7,6 +7,7 @@ import com.innerpeace.themoonha.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -26,6 +27,7 @@ import java.util.List;
  */
 @Service
 @RequiredArgsConstructor
+@Transactional
 @Slf4j
 public class LoungeServiceImpl implements LoungeService {
 

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -1,7 +1,9 @@
 package com.innerpeace.themoonha.domain.lounge.service;
 
-import com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse;
+import com.innerpeace.themoonha.domain.lounge.dto.*;
 import com.innerpeace.themoonha.domain.lounge.mapper.LoungeMapper;
+import com.innerpeace.themoonha.global.exception.CustomException;
+import com.innerpeace.themoonha.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ import java.util.List;
  * ----------  --------    ---------------------------
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       findLoungeList 메서드 추가
+ * 2024.08.25  	조희정       findLoungeHome 메서드 추가
  * </pre>
  */
 @Service
@@ -36,5 +39,28 @@ public class LoungeServiceImpl implements LoungeService {
     @Override
     public List<LoungeListResponse> findLoungeList(Long memberId) {
         return loungeMapper.selectLoungeList(memberId);
+    }
+
+    /**
+     * 라운지 홈 조회
+     * @param loungeId
+     * @param memberId
+     * @param role
+     * @return
+     */
+    @Override
+    public LoungeHomeResponse findLoungeHome(Long loungeId, Long memberId, String role) {
+        LoungeInfoDTO loungeInfo = loungeMapper.selectLoungeInfo(loungeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.LOUNGE_NOT_FOUND));
+        List<LoungePostDTO> loungePostList = loungeMapper.selectLoungePostList(loungeId);
+        List<AttendanceDTO> attendanceList = loungeMapper.selectAttendanceList(loungeId, memberId, role);
+        List<LoungeMemberDTO> loungeMemberList = loungeMapper.selectLoungeMemberList(loungeId);
+
+        return LoungeHomeResponse.of(
+                loungeInfo,
+                loungePostList,
+                attendanceList,
+                loungeMemberList
+        );
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -9,7 +9,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(404, "존재하지 않은 유저입니다."),
     LESSON_NOT_FOUND(404, "강좌가 존재하지 않습니다."),
     SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다."),
-    MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요.");
+    MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요."),
+    LOUNGE_NOT_FOUND(404, "라운지 정보가 존재하지 않습니다.");
     private final int status;
     private final String message;
 

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -258,28 +258,4 @@
                       and member_id = #{memberId}
             )
     </insert>
-
-    <select id="findTutorDetail"
-            resultType="com.innerpeace.themoonha.domain.lesson.dto.TutorLessonDetailDTO">
-
-        select
-            m.name,
-            m.profile_img_url,
-            l.lesson_id,
-            l.title,
-            l.thumbnail_url,
-            l.cnt,
-            l.end_date,
-            CASE
-                WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
-                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time END AS lesson_time
-        from
-            member m
-        join
-            lesson l
-        on
-            m.member_id = l.member_id
-        where
-            m.member_id = #{tutorId}
-    </select>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -258,4 +258,28 @@
                       and member_id = #{memberId}
             )
     </insert>
+
+    <select id="findTutorDetail"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.TutorLessonDetailDTO">
+
+        select
+            m.name,
+            m.profile_img_url,
+            l.lesson_id,
+            l.title,
+            l.thumbnail_url,
+            l.cnt,
+            l.end_date,
+            CASE
+                WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time END AS lesson_time
+        from
+            member m
+        join
+            lesson l
+        on
+            m.member_id = l.member_id
+        where
+            m.member_id = #{tutorId}
+    </select>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -40,7 +40,7 @@
 
     <select id="selectLoungeList"
             resultType="com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse">
-        SELECT
+        SELECT /*+ INDEX_DESC(lp PK_LOUNGE_POST) */
             lo.lounge_id,
             le.title,
             lo.lounge_img_url,
@@ -82,7 +82,7 @@
 
     <select id="selectLoungePostList"
             resultMap="LoungePostResultMap">
-        SELECT
+        SELECT /*+ INDEX_ASC(lp PK_LOUNGE_POST) ORDERED */
             lp.lounge_post_id,
             lp.content,
             lp.notice_yn,
@@ -95,14 +95,16 @@
             lounge_post lp
                 LEFT JOIN member lm ON lp.member_id = lm.member_id
                 LEFT JOIN lounge_post_img lpi ON lp.lounge_post_id = lpi.lounge_post_id
-
         WHERE
             lp.lounge_id = #{loungeId}
+        ORDER BY
+            lp.lounge_post_id DESC,
+            lpi.lounge_post_id ASC
     </select>
 
     <select id="selectAttendanceList"
             resultType="com.innerpeace.themoonha.domain.lounge.dto.AttendanceDTO">
-        SELECT
+        SELECT /*+ INDEX_ASC(a PK_ATTENDANCE) INDEX_ASC(sm PK_MEMBER) */
             a.attendance_date,
             a.attendance_yn,
             sm.member_id,
@@ -120,11 +122,14 @@
             <if test="role == 'ROLE_MEMBER'">
                 AND s.member_id = #{memberId}
             </if>
+        ORDER BY
+            a.attendance_date ASC,
+            sm.member_id ASC
     </select>
 
     <select id="selectLoungeMemberList"
             resultType="com.innerpeace.themoonha.domain.lounge.dto.LoungeMemberDTO">
-        SELECT
+        SELECT /*+ INDEX_ASC(m PK_MEMBER) */
             m.member_id,
             m.name,
             m.profile_img_url
@@ -135,6 +140,8 @@
             su.lesson_id = #{lessonId}
           AND su.online_yn = 0
           AND su.lounge_yn = 1
+        ORDER BY
+            m.member_id ASC
     </select>
 
 

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -13,9 +13,30 @@
  * ==========  =========    =========
  * 2024.08.25  	조희정        최초 생성
  * 2024.08.25  	조희정        selectLoungeList 쿼리 추가
+ * 2024.08.26  	조희정        selectLoungeInfo, selectLoungePostList, selectAttendanceList, selectLoungeMemberList 쿼리 추가
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lounge.mapper.LoungeMapper">
+    <!--라운지 홈 포스트 정보-->
+    <resultMap id="LoungePostResultMap" type="com.innerpeace.themoonha.domain.lounge.dto.LoungePostDTO">
+        <!-- 게시글 정보 -->
+        <id column="lounge_post_id" property="loungePostId"/>
+        <result column="content" property="content"/>
+        <result column="notice_yn" property="noticeYn"/>
+        <result column="created_at" property="createdAt"/>
+
+        <!-- 작성자 정보 -->
+        <association property="loungeMember" javaType="com.innerpeace.themoonha.domain.lounge.dto.LoungeMemberDTO">
+            <id column="member_id" property="memberId"/>
+            <result column="name" property="name"/>
+            <result column="profile_img_url" property="profileImgUrl"/>
+        </association>
+
+        <!-- 이미지 URL 리스트 -->
+        <collection property="loungePostImgList" ofType="string">
+            <result column="post_img_url"/>
+        </collection>
+    </resultMap>
 
     <select id="selectLoungeList"
             resultType="com.innerpeace.themoonha.domain.lounge.dto.LoungeListResponse">
@@ -41,5 +62,81 @@
           AND s.online_yn = 0
           AND s.lounge_yn = 1
     </select>
+
+    <select id="selectLoungeInfo"
+            resultType="com.innerpeace.themoonha.domain.lounge.dto.LoungeInfoDTO">
+        SELECT
+            le.lesson_id,
+            le.title,
+            lo.lounge_img_url,
+            m.member_id AS tutor_id,
+            m.name AS tutor_name,
+            le.summary
+        FROM
+            lesson le
+                JOIN member m ON le.member_id = m.member_id
+                JOIN lounge lo ON le.lesson_id = lo.lesson_id
+        WHERE
+            lo.lounge_id = #{loungeId}
+    </select>
+
+    <select id="selectLoungePostList"
+            resultMap="LoungePostResultMap">
+        SELECT
+            lp.lounge_post_id,
+            lp.content,
+            lp.notice_yn,
+            lp.created_at,
+            lm.member_id,
+            lm.name,
+            lm.profile_img_url,
+            lpi.post_img_url
+        FROM
+            lounge_post lp
+                LEFT JOIN member lm ON lp.member_id = lm.member_id
+                LEFT JOIN lounge_post_img lpi ON lp.lounge_post_id = lpi.lounge_post_id
+
+        WHERE
+            lp.lounge_id = #{loungeId}
+    </select>
+
+    <select id="selectAttendanceList"
+            resultType="com.innerpeace.themoonha.domain.lounge.dto.AttendanceDTO">
+        SELECT
+            a.attendance_date,
+            a.attendance_yn,
+            sm.member_id,
+            sm.name
+        FROM
+            attendance a
+                JOIN sugang s ON a.sugang_id = s.sugang_id
+                LEFT JOIN member sm ON s.member_id = sm.member_id
+        WHERE
+            s.lesson_id = (
+                SELECT lesson_id
+                FROM lounge
+                WHERE lounge_id = #{loungeId}
+                )
+            <if test="role == 'ROLE_MEMBER'">
+                AND s.member_id = #{memberId}
+            </if>
+    </select>
+
+    <select id="selectLoungeMemberList"
+            resultType="com.innerpeace.themoonha.domain.lounge.dto.LoungeMemberDTO">
+        SELECT
+            m.member_id,
+            m.name,
+            m.profile_img_url
+        FROM
+            sugang su
+                JOIN member m ON su.member_id = m.member_id
+        WHERE
+            su.lesson_id = #{lessonId}
+          AND su.online_yn = 0
+          AND su.lounge_yn = 1
+    </select>
+
+
 
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
라운지 홈 화면 조회 구현했습니다.

## ⭐️ 관련 이슈
- closes : #18 

## 📍 작업한 내용
- 라운지 홈 화면 조회 구현

## 🔎 결과 및 이슈 공유
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/f9c9094c-b4f8-47f3-b41a-47c5cb2c14d3">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
