### PR TITLE
[LESSON] [KAN-26] 강좌 수강 신청 기능 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -86,8 +86,8 @@ public class LessonController {
     }
 
     @PostMapping("/pay")
-    public ResponseEntity<CommonResponse> lessonPayment(@RequestBody List<Long> cartIdList) {
+    public ResponseEntity<CommonResponse> lessonPayment(@RequestBody SugangRequest sugangRequest) {
         Long memberId = 1L;
-        return ResponseEntity.ok(lessonService.payLesson(cartIdList, memberId));
+        return ResponseEntity.ok(lessonService.payLesson(sugangRequest.getCartIdList(), memberId));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -24,7 +24,7 @@ import java.util.List;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 기능 추가
+ * 2024.08.26   손승완       장바구니 및 신청 기능 추가
  * </pre>
  */
 @RestController
@@ -85,4 +85,9 @@ public class LessonController {
         return ResponseEntity.ok(lessonService.addCart(cartRequest));
     }
 
+    @PostMapping("/pay")
+    public ResponseEntity<CommonResponse> lessonPayment(@RequestBody List<Long> cartIdList) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(lessonService.payLesson(cartIdList, memberId));
+    }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/SugangRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/SugangRequest.java
@@ -1,0 +1,12 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SugangRequest {
+    private List<Long> cartIdList;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.lesson.mapper;
 
 import com.innerpeace.themoonha.domain.lesson.dto.*;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +18,7 @@ import java.util.Optional;
  * 2024.08.24  	손승완       최초 생성
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 기능 추가
+ * 2024.08.26   손승완       장바구니 및 신청 기능 추가
  * </pre>
  */
 public interface LessonMapper {
@@ -27,5 +28,8 @@ public interface LessonMapper {
     List<TutorLessonDetailDTO> selectTutorDetail(Long tutorId);
     List<CartResponse> selectCartList(Long memberId);
     int insertCart(CartRequest cartRequest);
-
+    int deleteCart(@Param("cartIdList") List<Long> cartIdList,
+                   @Param("memberId") Long memberId);
+    int insertSugang(@Param("cartIdList") List<Long> cartIdList,
+                     @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -18,19 +18,15 @@ import java.util.List;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 기능 추가
+ * 2024.08.26   손승완       장바구니 및 신청 기능 추가
  * </pre>
  */
 public interface LessonService {
     LessonListResponse findLessonList(LessonListRequest lessonListRequest);
-
     LessonDetailResponse findLessonDetail(Long lessonId);
-
     ShortFormDetailResponse findShortFormDetail(Long shortFormId);
-
     TutorDetailResponse findTutorDetail(Long tutorId);
-
     List<CartResponse> findCartList(Long memberId);
-
     CommonResponse addCart(CartRequest cartRequest);
+    CommonResponse payLesson(List<Long> cartIdList, Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Optional;
  *
  * @author 손승완
  * @version 1.0
+ * @since 2024.08.24
  *
  * <pre>
  * 수정일        수정자        수정내용
@@ -27,9 +28,8 @@ import java.util.Optional;
  * 2024.08.25   손승완       강좌 상세보기 기능 추가
  * 2024.08.25   손승완       숏폼 상세보기 기능 추가
  * 2024.08.26   손승완       강사 상세보기 기능 추가
- * 2024.08.26   손승완       장바구니 기능 추가
+ * 2024.08.26   손승완       장바구니 및 신청 기능 추가
  * </pre>
- * @since 2024.08.24
  */
 @Service
 @RequiredArgsConstructor
@@ -85,4 +85,19 @@ public class LessonServiceImpl implements LessonService {
 
         throw new CustomException(ErrorCode.CART_LESSON_ALREADY_EXISTS);
     }
+
+    @Override
+    @Transactional
+    public CommonResponse payLesson(List<Long> cartIdList, Long memberId) {
+        if (lessonMapper.insertSugang(cartIdList, memberId) != cartIdList.size()) {
+            throw new CustomException(ErrorCode.SUGANG_FAILED);
+        }
+
+        if (lessonMapper.deleteCart(cartIdList, memberId) != cartIdList.size()) {
+            throw new CustomException(ErrorCode.SUGANG_FAILED);
+        }
+
+        return CommonResponse.of(true, SuccessCode.SUGANG_APPLICATION_SUCCESS.getMessage());
+    }
+
 }

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     SHORTFORM_NOT_FOUND(404, "숏폼이 존재하지 않습니다."),
     MEMBER_DUPLICATE(409, "중복되는 유저가 존재합니다. 다시 시도해주세요."),
     TUTOR_NOT_FOUND(404, "강사가 존재하지 않습니다"),
-    CART_LESSON_ALREADY_EXISTS(409, "강좌가 이미 장바구니에 담겨있습니다.");
+    CART_LESSON_ALREADY_EXISTS(409, "강좌가 이미 장바구니에 담겨있습니다."),
+    SUGANG_FAILED(400, "수강신청에 실패했습니다.");
     private final int status;
     private final String message;
 

--- a/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessCode {
-    CART_LESSON_ADDED_SUCCESS(200, "강좌가 성고적으로 장바구니에 담겼습니다");
+    CART_LESSON_ADDED_SUCCESS(200, "강좌가 성공적으로 장바구니에 담겼습니다"),
+    SUGANG_APPLICATION_SUCCESS(200, "수강신청이 완료되었습니다");
     private final int status;
     private final String message;
 }

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -14,7 +14,7 @@
  * 2024.08.24  	손승완        최초 생성
  * 2024.08.25   손승완        강좌 상세 조회 쿼리 추가
  * 2024.08.26   손승완        강사 상세 조회 쿼리 추가
- * 2024.08.26   손승완        장바구니 쿼리 추가
+ * 2024.08.26   손승완        장바구니 및 수강신청 쿼리 추가
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
@@ -165,7 +165,6 @@
     <select id="selectShortFormDetail"
             resultType="com.innerpeace.themoonha.domain.lesson.dto.ShortFormDetailResponse">
         select
-
             l.lesson_id,
             m.name tutor_name,
             s.name short_form_name,
@@ -189,7 +188,6 @@
 
     <select id="selectTutorDetail"
             resultType="com.innerpeace.themoonha.domain.lesson.dto.TutorLessonDetailDTO">
-
         select
             m.name,
             m.profile_img_url,
@@ -240,7 +238,9 @@
         on
             l.branch_id = b.branch_id
         where
-            m.member_id = 1
+            m.member_id = #{memberId} and c.deleted_at is null
+        order by
+            b.branch_id
     </select>
 
     <insert id="insertCart">
@@ -258,4 +258,36 @@
                       and member_id = #{memberId}
             )
     </insert>
+
+    <insert id="insertSugang" parameterType="java.util.List">
+        insert into
+            sugang(sugang_id, lesson_id, member_id, online_yn, lounge_yn)
+        select
+            sugang_seq.nextval,
+            lesson_id,
+            member_id,
+            online_yn,
+            case when online_yn = 1 then 0 else 1 end as lounge_yn
+        from
+            cart
+        where
+            member_id = #{memberId} and
+            cart_id in
+            <foreach item="cartId" collection="cartIdList" open="(" separator="," close=")">
+                #{cartId}
+            </foreach>
+    </insert>
+
+    <update id="deleteCart">
+        update
+            cart
+        set
+            deleted_at = current_date
+        where
+            member_id = #{memberId} and
+            cart_id in
+            <foreach item="cartId" collection="cartIdList" open="(" separator="," close=")">
+                #{cartId}
+            </foreach>
+    </update>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -285,6 +285,7 @@
             deleted_at = current_date
         where
             member_id = #{memberId} and
+            deleted_at is null and
             cart_id in
             <foreach item="cartId" collection="cartIdList" open="(" separator="," close=")">
                 #{cartId}


### PR DESCRIPTION
# 💡 PR 요약
장바구니에 담긴 강좌에 대한 수강 신청 기능을 구현했습니다.

## ⭐️ 관련 이슈
- closes : #22 

## 📍 작업한 내용
- 강좌 수강신청 API 구현

## 🔎 결과 및 이슈 공유
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/a2cde6b6-a894-4d09-9980-b664bdde3d49">
<img width="987" alt="image" src="https://github.com/user-attachments/assets/b2b36618-e2fd-4c29-a30d-b2b0817ae1a0">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
