### PR TITLE
[LOUNGE] [KAN-29] 라운지 게시글, 댓글 등록 기능 추가

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
@@ -2,13 +2,11 @@ package com.innerpeace.themoonha.domain.lounge.controller;
 
 import com.innerpeace.themoonha.domain.lounge.dto.*;
 import com.innerpeace.themoonha.domain.lounge.service.LoungeService;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,6 +22,7 @@ import java.util.List;
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       loungeList 메서드 추가
  * 2024.08.26  	조희정       loungeHome, loungePostDetail 메서드 추가
+ * 2024.08.27  	조희정       loungePostRegister, loungeCommentRegister 메서드 추가
  * </pre>
  */
 @RestController
@@ -65,5 +64,27 @@ public class LoungeController {
     @GetMapping("/{loungeId}/post/{loungePostId}")
     public ResponseEntity<LoungePostDetailDTO> loungePostDetail(@PathVariable Long loungeId, @PathVariable Long loungePostId) {
         return ResponseEntity.ok(loungeService.findLoungePostDetail(loungePostId));
+    }
+
+    /**
+     * 라운지 게시글 등록
+     * @param loungePostRequest
+     * @return
+     */
+    @PostMapping("/post/register")
+    public ResponseEntity<CommonResponse> loungePostRegister(@RequestBody LoungePostRequest loungePostRequest) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(loungeService.addLoungePost(loungePostRequest, memberId));
+    }
+
+    /**
+     * 라운지 댓글 등록
+     * @param loungeCommentRequest
+     * @return
+     */
+    @PostMapping("/comment/register")
+    public ResponseEntity<CommonResponse> loungeCommentRegister(@RequestBody LoungeCommentRequest loungeCommentRequest) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(loungeService.addLoungeComment(loungeCommentRequest, memberId));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeCommentRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeCommentRequest.java
@@ -1,0 +1,26 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 라운지 댓글 작성 Request
+ * @author 조희정
+ * @since 2024.08.27
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.27  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungeCommentRequest {
+    private Long loungePostId;
+    private String content;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostRequest.java
@@ -1,0 +1,28 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 라운지 게시글 작성 Request
+ * @author 조희정
+ * @since 2024.08.27
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.27  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoungePostRequest {
+    private Long loungePostId;
+    private Long loungeId;
+    private String content;
+    private Boolean noticeYn;
+    private List<String> loungePostImgList;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       selectLoungeList 메서드 생성
  * 2024.08.26  	조희정       selectLoungeInfo, selectLoungePostList, selectAttendanceList, selectLoungeMemberList, selectLoungePostDetail 메서드 생성
- * 2024.08.26  	조희정       selectLoungePostImgList, selectLoungeCommentList 메서드 생성
+ * 2024.08.27  	조희정       selectLoungePostImgList, selectLoungeCommentList, insertLoungePost, insertLoungePostImgUrls, insertLoungeComment 메서드 생성
  * </pre>
  */
 public interface LoungeMapper {
@@ -81,4 +81,27 @@ public interface LoungeMapper {
      * @return
      */
     List<LoungeCommentDTO> selectLoungeCommentList(Long loungePostId);
+
+    /**
+     * 라운지 게시물 등록
+     * @param loungePostRequest
+     * @return
+     */
+    int insertLoungePost(@Param("loungePostRequest") LoungePostRequest loungePostRequest, @Param("memberId") Long memberId);
+
+    /**
+     * 라운지 게시물 이미지 등록
+     * @param loungePostId
+     * @param postImgUrl
+     * @return
+     */
+    int insertLoungePostImgUrls(@Param("loungePostId") Long loungePostId, @Param("postImgUrl") String postImgUrl);
+
+    /**
+     * 라운지 댓글 등록
+     * @param loungeCommentRequest
+     * @param memberId
+     * @return
+     */
+    int insertLoungeComment(@Param("loungeComment") LoungeCommentRequest loungeCommentRequest, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.lounge.service;
 
 import com.innerpeace.themoonha.domain.lounge.dto.*;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ import java.util.List;
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       findLoungeList 메서드 추가
  * 2024.08.26  	조희정       findLoungeHome, findLoungePostDetail 메서드 추가
+ * 2024.08.27  	조희정       addLoungePost, addLoungeComment 메서드 추가
  * </pre>
  */
 public interface LoungeService {
@@ -41,4 +43,19 @@ public interface LoungeService {
      * @return
      */
     LoungePostDetailDTO findLoungePostDetail(Long loungePostId);
+
+    /**
+     * 라운지 게시글 등록
+     * @param loungePostRequest
+     * @return
+     */
+    CommonResponse addLoungePost(LoungePostRequest loungePostRequest, Long memberId);
+
+    /**
+     * 라운지 게시물에 댓글 등록
+     * @param loungeCommentRequest
+     * @param memberId
+     * @return
+     */
+    CommonResponse addLoungeComment(LoungeCommentRequest loungeCommentRequest, Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -100,6 +100,7 @@ public class LoungeServiceImpl implements LoungeService {
     /**
      * 라운지 게시물 등록
      * @param loungePostRequest
+     * @param memberId
      * @return
      */
     @Override
@@ -109,6 +110,7 @@ public class LoungeServiceImpl implements LoungeService {
             throw new CustomException(ErrorCode.LOUNGE_POST_FAILED);
         };
 
+        // 이미지 저장
         if (loungePostRequest.getLoungePostImgList() != null && !loungePostRequest.getLoungePostImgList().isEmpty()) {
             for (String postImgUrl : loungePostRequest.getLoungePostImgList()) {
                 if (loungeMapper.insertLoungePostImgUrls(loungePostRequest.getLoungePostId(), postImgUrl) != 1) {

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -2,8 +2,10 @@ package com.innerpeace.themoonha.domain.lounge.service;
 
 import com.innerpeace.themoonha.domain.lounge.dto.*;
 import com.innerpeace.themoonha.domain.lounge.mapper.LoungeMapper;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
+import com.innerpeace.themoonha.global.vo.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +25,8 @@ import java.util.stream.Collectors;
  * ----------  --------    ---------------------------
  * 2024.08.25  	조희정       최초 생성
  * 2024.08.25  	조희정       findLoungeList 메서드 추가
- * 2024.08.25  	조희정       findLoungeHome, findLoungePostDetail 메서드 추가
+ * 2024.08.26  	조희정       findLoungeHome, findLoungePostDetail 메서드 추가
+ * 2024.08.27  	조희정       addLoungePost, addLoungeComment 메서드 추가
  * </pre>
  */
 @Service
@@ -92,5 +95,42 @@ public class LoungeServiceImpl implements LoungeService {
                 loungePost,
                 loungeCommentList
         );
+    }
+
+    /**
+     * 라운지 게시물 등록
+     * @param loungePostRequest
+     * @return
+     */
+    @Override
+    public CommonResponse addLoungePost(LoungePostRequest loungePostRequest, Long memberId) {
+        // 게시물 저장
+        if(loungeMapper.insertLoungePost(loungePostRequest, memberId) != 1) {
+            throw new CustomException(ErrorCode.LOUNGE_POST_FAILED);
+        };
+
+        if (loungePostRequest.getLoungePostImgList() != null && !loungePostRequest.getLoungePostImgList().isEmpty()) {
+            for (String postImgUrl : loungePostRequest.getLoungePostImgList()) {
+                if (loungeMapper.insertLoungePostImgUrls(loungePostRequest.getLoungePostId(), postImgUrl) != 1) {
+                    throw new CustomException(ErrorCode.LOUNGE_POST_FAILED);
+                }
+            }
+        }
+
+        return CommonResponse.of(true, SuccessCode.LOUNGE_POST_ADD_SUCCESS.getMessage());
+    }
+
+    /**
+     * 라운지 게시물에 댓글 등록
+     * @param loungeCommentRequest
+     * @param memberId
+     * @return
+     */
+    @Override
+    public CommonResponse addLoungeComment(LoungeCommentRequest loungeCommentRequest, Long memberId) {
+        if(loungeMapper.insertLoungeComment(loungeCommentRequest, memberId) != 1) {
+            throw new CustomException(ErrorCode.LOUNGE_COMMENT_FAILED);
+        }
+        return CommonResponse.of(true, SuccessCode.LOUNGE_COMMENT_ADD_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/exception/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
     CART_LESSON_ALREADY_EXISTS(409, "강좌가 이미 장바구니에 담겨있습니다."),
     SUGANG_FAILED(400, "수강신청에 실패했습니다."),
     LOUNGE_NOT_FOUND(404, "라운지 정보가 존재하지 않습니다."),
-    LOUNGE_POST_NOT_FOUND(404, "라운지 게시글 정보가 존재하지 않습니다.");
+    LOUNGE_POST_NOT_FOUND(404, "라운지 게시글 정보가 존재하지 않습니다."),
+    LOUNGE_POST_FAILED(400, "라운지 게시글 작성에 실패했습니다."),
+    LOUNGE_COMMENT_FAILED(400, "라운지 댓글 작성에 실패했습니다.");
     private final int status;
     private final String message;
 

--- a/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SuccessCode {
     CART_LESSON_ADDED_SUCCESS(200, "강좌가 성공적으로 장바구니에 담겼습니다"),
-    SUGANG_APPLICATION_SUCCESS(200, "수강신청이 완료되었습니다");
+    SUGANG_APPLICATION_SUCCESS(200, "수강신청이 완료되었습니다"),
+    LOUNGE_POST_ADD_SUCCESS(200, "라운지에 게시물이 등록되었습니다."),
+    LOUNGE_COMMENT_ADD_SUCCESS(200, "라운지에 댓글이 등록되었습니다.");
     private final int status;
     private final String message;
 }

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -14,7 +14,7 @@
  * 2024.08.25  	조희정        최초 생성
  * 2024.08.25  	조희정        selectLoungeList 쿼리 추가
  * 2024.08.26  	조희정        selectLoungeInfo, selectLoungePostList, selectAttendanceList, selectLoungeMemberList, selectLoungePostDetail 쿼리 추가
- * 2024.08.26  	조희정       selectLoungePostImgList, selectLoungeCommentList 쿼리 추가
+ * 2024.08.27  	조희정        selectLoungePostImgList, selectLoungeCommentList 쿼리 추가
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lounge.mapper.LoungeMapper">
@@ -207,5 +207,26 @@
                 ORDER BY
                     lc.lounge_comment_id ASC
     </select>
+
+    <!-- 라운지 게시물 등록 -->
+    <insert id="insertLoungePost" keyProperty="loungePostRequest.loungePostId">
+        <selectKey keyProperty="loungePostRequest.loungePostId" resultType="long" order="BEFORE">
+            SELECT lounge_post_seq.nextval from dual
+        </selectKey>
+        INSERT INTO lounge_post (lounge_post_id, member_id, lounge_id, content, notice_yn)
+        VALUES (#{loungePostRequest.loungePostId}, #{memberId}, #{loungePostRequest.loungeId}, #{loungePostRequest.content}, #{loungePostRequest.noticeYn})
+    </insert>
+
+    <!-- 라운지 게시물 이미지 등록 -->
+    <insert id="insertLoungePostImgUrls">
+        INSERT INTO lounge_post_img (lounge_post_img_id, lounge_post_id, post_img_url)
+        VALUES (lounge_post_img_seq.nextval, #{loungePostId}, #{postImgUrl})
+    </insert>
+
+    <!-- 라운지 댓글 등록 -->
+    <insert id="insertLoungeComment">
+        INSERT INTO lounge_comment(lounge_comment_id, member_id, lounge_post_id, content)
+        VALUES (lounge_comment_seq.nextval, #{memberId}, #{loungeComment.loungePostId}, #{loungeComment.content})
+    </insert>
 
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
라운지 게시글, 댓글 등록 기능 추가했습니다.

## ⭐️ 관련 이슈
- closes : #30 

## 📍 작업한 내용
- 라운지 게시글 등록 기능
- 라운지 댓글 등록 기능

## 🔎 결과 및 이슈 공유
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/eb074c4d-bbaf-46d9-8eb6-a00da17e8cc4">
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/a35bd230-0667-4bfc-b7cb-faee40add240">
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/22d8fe6b-ea92-402d-b4da-a92a8a5213eb">



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
