### PR TITLE
[ADMIN] [KAN-13] 어드민 전체 강좌 조회 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminLessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminLessonController.java
@@ -5,6 +5,7 @@ import com.innerpeace.themoonha.domain.admin.dto.AdminLessonListRequest;
 import com.innerpeace.themoonha.domain.admin.dto.LessonRegisterRequest;
 import com.innerpeace.themoonha.domain.admin.service.AdminLessonService;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
+import com.innerpeace.themoonha.global.vo.SuccessCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	최유경       최초 생성
+ * 2024.08.28   최유경       강좌 조희 기능
  * </pre>
  */
 @RestController
@@ -42,7 +44,7 @@ public class AdminLessonController {
         log.info("/admin/lesson/register : {}", registerRequest.toString());
         adminLessonService.addLesson(registerRequest, thumbnailFile, previewVideoFile);
 
-        return ResponseEntity.ok(CommonResponse.from("강좌 등록이 완료되었습니다."));
+        return ResponseEntity.ok(CommonResponse.from(SuccessCode.ADMIN_LESSON_REGISTER_SUCCESS.getMessage()));
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminLessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminLessonController.java
@@ -1,15 +1,16 @@
 package com.innerpeace.themoonha.domain.admin.controller;
 
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonResponse;
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonListRequest;
 import com.innerpeace.themoonha.domain.admin.dto.LessonRegisterRequest;
 import com.innerpeace.themoonha.domain.admin.service.AdminLessonService;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
-import com.innerpeace.themoonha.global.service.S3Service;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import oracle.ucp.proxy.annotation.Post;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,7 +34,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AdminLessonController {
     private final AdminLessonService adminLessonService;
-    private final S3Service s3Service;
 
     @PostMapping("/register")
     public ResponseEntity<CommonResponse> LessonAdd(@RequestPart("registerRequest") LessonRegisterRequest registerRequest,
@@ -44,4 +44,14 @@ public class AdminLessonController {
 
         return ResponseEntity.ok(CommonResponse.from("강좌 등록이 완료되었습니다."));
     }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<AdminLessonResponse>> LessonList(AdminLessonListRequest lessonListRequest){
+        log.info("LessonList : {}", lessonListRequest.toString());
+        List<AdminLessonResponse> lessonDTOList = adminLessonService.findLessonList(lessonListRequest);
+        return ResponseEntity.ok(lessonDTOList);
+    }
+
+
+
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonListRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonListRequest.java
@@ -1,0 +1,20 @@
+package com.innerpeace.themoonha.domain.admin.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class AdminLessonListRequest {
+    private Long branchId;
+    private String lessonTitle;
+    private String tutorName;
+    private String day;
+    private Integer target;
+    private Long categoryId;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonListRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonListRequest.java
@@ -6,6 +6,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * 어드민 강좌 조회 요청 dto
+ * @author 최유경
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonResponse.java
@@ -1,0 +1,37 @@
+package com.innerpeace.themoonha.domain.admin.dto;
+
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class AdminLessonResponse {
+    private Long lessonId;
+    private Long branchId;
+    private String branchName;
+    private Long categoryId;
+    private String category;
+    private Long memberId;
+    private String tutorName;
+    private String title;
+    private int cnt;
+    private int cost;
+    private String previewVideoUrl;
+    private String thumbnailUrl;
+    private String startDate;
+    private String endDate;
+    private String lessonTime;
+    private String day;
+    private String place;
+    private int target;
+    private int onlineCost;
+    private Date createdAt;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/AdminLessonResponse.java
@@ -8,6 +8,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * 어드민 강좌 조회 응답 dto
+ * @author 최유경
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/LessonRegisterRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/LessonRegisterRequest.java
@@ -1,6 +1,5 @@
 package com.innerpeace.themoonha.domain.admin.dto;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +7,18 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * 어드민 강좌 등록 요청 dto
+ * @author 최유경
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @Setter
 @AllArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.java
@@ -7,6 +7,18 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+/**
+ * 어드민 강좌 관리 매퍼
+ * @author 최유경
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.28  	최유경       최초 생성
+ * </pre>
+ */
 @Mapper
 public interface AdminLessonMapper {
     int selectLessonByTutorSchedule(LessonRegisterRequest lessonRegisterRequest);

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.java
@@ -1,6 +1,9 @@
 package com.innerpeace.themoonha.domain.admin.mapper;
 
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonListRequest;
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonResponse;
 import com.innerpeace.themoonha.domain.admin.dto.LessonRegisterRequest;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -10,5 +13,7 @@ public interface AdminLessonMapper {
     int insertLesson(@Param("registerRequest") LessonRegisterRequest registerRequest,
                      @Param("thumbnailS3Url") String thumbnailS3Url,
                      @Param("previewS3Url") String previewS3Url);
+
+    List<AdminLessonResponse> selectLessonList(AdminLessonListRequest lessonListRequest);
 
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonService.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	최유경       최초 생성
+ * 2024.08.28   최유경       강좌 조희 기능
  * </pre>
  */
 public interface AdminLessonService {

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonService.java
@@ -1,6 +1,9 @@
 package com.innerpeace.themoonha.domain.admin.service;
 
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonResponse;
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonListRequest;
 import com.innerpeace.themoonha.domain.admin.dto.LessonRegisterRequest;
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -18,4 +21,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface AdminLessonService {
 
     void addLesson(LessonRegisterRequest registerRequest, MultipartFile thumbnailFile, MultipartFile previewVideoFile);
+    List<AdminLessonResponse> findLessonList(AdminLessonListRequest lessonListRequest);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	최유경       최초 생성
+ * 2024.08.28   최유경       강좌 조희 기능
  * </pre>
  */
 @Service
@@ -34,6 +35,13 @@ public class AdminLessonServiceImpl implements AdminLessonService {
     private final AdminLessonMapper adminLessonMapper;
     private final S3Service s3Service;
 
+    /**
+     * 강좌 등록 메서드
+     *
+     * @param registerRequest 강좌 등록 요청 dto
+     * @param thumbnailFile 강좌 썸네일 사진 파일
+     * @param previewVideoFile 강좌 프리뷰 영상 파일
+     */
     @Override
     @Transactional
     public void addLesson(LessonRegisterRequest registerRequest, MultipartFile thumbnailFile, MultipartFile previewVideoFile) {
@@ -61,6 +69,12 @@ public class AdminLessonServiceImpl implements AdminLessonService {
     }
 
 
+    /**
+     * 강좌 조회 메서드
+     *
+     * @param lessonListRequest 조회 필터 요청 dto
+     * @return 조회 결과 dto
+     */
     @Override
     public List<AdminLessonResponse> findLessonList(AdminLessonListRequest lessonListRequest) {
         return adminLessonMapper.selectLessonList(lessonListRequest);

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminLessonServiceImpl.java
@@ -1,11 +1,14 @@
 package com.innerpeace.themoonha.domain.admin.service;
 
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonResponse;
+import com.innerpeace.themoonha.domain.admin.dto.AdminLessonListRequest;
 import com.innerpeace.themoonha.domain.admin.dto.LessonRegisterRequest;
 import com.innerpeace.themoonha.domain.admin.mapper.AdminLessonMapper;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
 import com.innerpeace.themoonha.global.service.S3Service;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -55,5 +58,11 @@ public class AdminLessonServiceImpl implements AdminLessonService {
         // 데이터베이스에 저장하기
         if(adminLessonMapper.insertLesson(registerRequest, thumbnailS3Url, previewS3Url)!=1)
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+
+    @Override
+    public List<AdminLessonResponse> findLessonList(AdminLessonListRequest lessonListRequest) {
+        return adminLessonMapper.selectLessonList(lessonListRequest);
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
@@ -17,7 +17,8 @@ public enum SuccessCode {
     LOUNGE_POST_DELETE_SUCCESS(200, "라운지 게시물이 삭제되었습니다."),
     WISHLESSON_VOTE_SUCCESS(200, "듣고싶은 강좌에 투표를 완료했습니다"),
     AUTH_SIGNUP_SUCCESS(200,"회원가입에 성공하였습니다."),
-    AUTH_LOGIN_SUCCESS(200, "로그인에 성공하였습니다.");
+    AUTH_LOGIN_SUCCESS(200, "로그인에 성공하였습니다."),
+    ADMIN_LESSON_REGISTER_SUCCESS(200,"강좌 등록이 완료되었습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.xml
@@ -121,7 +121,7 @@
                 AND l.target = #{target}
             </if>
 
-            <if test="categoryId != null and categoryId != ''">
+            <if test="categoryId != null">
                 AND c.category = #{categoryId}
             </if>
             AND l.deleted_at IS NULL

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminLessonMapper.xml
@@ -58,4 +58,73 @@
                 #{registerRequest.onlineCost})
         ]]>
     </insert>
+
+    <select id="selectLessonList"
+            parameterType="com.innerpeace.themoonha.domain.admin.dto.AdminLessonListRequest"
+            resultType="com.innerpeace.themoonha.domain.admin.dto.AdminLessonResponse">
+        SELECT
+            l.lesson_id,
+            l.branch_id,
+            b.name branch_name,
+            l.category_id,
+            c.category,
+            l.member_id,
+            m.name tutor_name,
+            l.title,
+            l.cnt,
+            l.cost,
+            l.thumbnail_url,
+            l.preview_video_url,
+            l.start_date,
+            l.end_date,
+            CASE
+                WHEN l.cnt = 1 THEN l.start_date || ' ' || l.start_time || '~' || l.end_time
+                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
+            END AS  lesson_time,
+            l.day || '요일' day,
+            l.place,
+            l.target,
+            l.online_cost,
+            l.created_at
+        FROM
+            lesson l
+            JOIN
+            branch b
+            ON
+            l.branch_id = b.branch_id
+            JOIN
+            member m
+            ON
+            l.member_id = m.member_id
+            JOIN
+            category c
+            ON
+            l.category_id = c.category_id
+        <where>
+            <if test="branchId != null">
+                l.branch_id = #{branchId}
+            </if>
+
+            <if test="lessonTitle != null and lessonTitle != ''">
+                AND l.title LIKE '%' || #{lessonTitle} || '%'
+            </if>
+
+            <if test="tutorName != null and tutorName != ''">
+                AND m.name LIKE #{tutorName} || '%'
+            </if>
+
+            <if test="day != null">
+                AND l.day = #{day}
+            </if>
+
+            <if test="target != null">
+                AND l.target = #{target}
+            </if>
+
+            <if test="categoryId != null and categoryId != ''">
+                AND c.category = #{categoryId}
+            </if>
+            AND l.deleted_at IS NULL
+        </where>
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
어드민 전체 강좌 조회 구현

## ⭐️ 관련 이슈
- closes : #50 

## 📍 작업한 내용
- 브랜치, 강좌명, 강사 이름, 요일, 수강 대상, 카테고리 별로 조회 가능

## 🔎 결과 및 이슈 공유
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/7a2e87f6-4918-49cf-836e-77a576d72309">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
