### PR TITLE
[LESSON] [KAN-12] 강좌 목록 조회 쿼리 및 로직 수정

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListDTO.java
@@ -1,0 +1,28 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 강좌 목록 조회 쿼리 DTO
+ *
+ * @author 손승완
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	손승완       최초 생성
+ * </pre>
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LessonListDTO {
+    private String branchName;
+    private List<LessonDTO> lessonList;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListDTO.java
@@ -23,6 +23,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LessonListDTO {
-    private String branchName;
+    private Long branchId;
     private List<LessonDTO> lessonList;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListRequest.java
@@ -1,25 +1,53 @@
 package com.innerpeace.themoonha.domain.lesson.dto;
 
 import com.innerpeace.themoonha.domain.lesson.vo.LessonTime;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+/**
+ * 강좌 목록 요청 DTO
+ *
+ * @author 손승완
+ * @since 2024.08.25
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.25  	손승완       최초 생성
+ * </pre>
+ */
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 public class LessonListRequest {
-    private String branchName;
+    private Long branchId;
     private String lessonTitle;
     private String tutorName;
     private String day;
     private Integer target;
-    private String category;
+    private Long categoryId;
     private Integer cnt;
     private Integer lessonTime;
     private String startTime;
     private String endTime;
 
-    public void setLessonTime() {
+    public LessonListRequest(Long branchId, String lessonTitle, String tutorName, String day,
+                             Integer target, Long categoryId, Integer cnt, Integer lessonTime) {
+        this.branchId = branchId;
+        this.lessonTitle = lessonTitle;
+        this.tutorName = tutorName;
+        this.day = day;
+        this.target = target;
+        this.categoryId = categoryId;
+        this.cnt = cnt;
+        this.lessonTime = lessonTime;
+        setLessonTime();
+    }
+
+    private void setLessonTime() {
         LessonTime selectedTime = LessonTime.findLessonTime(lessonTime);
         if (selectedTime != null) {
             this.startTime = selectedTime.getStartTime();

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListResponse.java
@@ -22,7 +22,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LessonListResponse {
-    private String branchName;
+    private Long branchId;
     private List<ShortFormDTO> shortFormList;
     private String memberName;
     private List<LessonDTO> lessonList;
@@ -32,7 +32,7 @@ public class LessonListResponse {
 
         return LessonListResponse.builder()
                 .lessonList(lessonList.getLessonList())
-                .branchName(lessonList.getBranchName())
+                .branchId(lessonList.getBranchId())
                 .shortFormList(shortFormList)
                 .memberName(memberName)
                 .build();

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonListResponse.java
@@ -14,10 +14,10 @@ import java.util.List;
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
  * 2024.08.24  	손승완       최초 생성
+ * 2024.08.30  	손승완       정적 팩토리 메서드 패턴 추가 및 setter 제거
  * </pre>
  */
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,4 +26,15 @@ public class LessonListResponse {
     private List<ShortFormDTO> shortFormList;
     private String memberName;
     private List<LessonDTO> lessonList;
+
+    public static LessonListResponse of(LessonListDTO lessonList, List<ShortFormDTO> shortFormList,
+                                        String memberName) {
+
+        return LessonListResponse.builder()
+                .lessonList(lessonList.getLessonList())
+                .branchName(lessonList.getBranchName())
+                .shortFormList(shortFormList)
+                .memberName(memberName)
+                .build();
+    }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -22,7 +22,8 @@ import java.util.Optional;
  * </pre>
  */
 public interface LessonMapper {
-    Optional<LessonListResponse> selectLessonList(LessonListRequest lessonListRequest);
+    Optional<LessonListDTO> selectLessonList(LessonListRequest lessonListRequest);
+    List<ShortFormDTO> selectShortFormList();
     Optional<LessonDetailResponse> selectLessonDetail(Long lessonId);
     Optional<ShortFormDetailResponse> selectShortFormDetail(Long shortFormId);
     List<TutorLessonDetailDTO> selectTutorDetail(Long tutorId);

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -39,15 +39,15 @@ public class LessonServiceImpl implements LessonService {
     private final LessonMapper lessonMapper;
 
     @Override
+    @Transactional(readOnly = true)
     public LessonListResponse findLessonList(LessonListRequest lessonListRequest) {
         String memberName = "고객1"; // 임시값
-        lessonListRequest.setLessonTime();
 
-        LessonListResponse lessonListResponse = lessonMapper.selectLessonList(lessonListRequest)
+        LessonListDTO lessonList = lessonMapper.selectLessonList(lessonListRequest)
                 .orElseThrow(() -> new CustomException(ErrorCode.LESSON_NOT_FOUND));
-        lessonListResponse.setMemberName(memberName);
+        List<ShortFormDTO> shortFormList = lessonMapper.selectShortFormList();
 
-        return lessonListResponse;
+        return LessonListResponse.of(lessonList, shortFormList, memberName);
     }
 
     @Override

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -19,9 +19,8 @@
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
 
-    <resultMap id="LessonListResponseMap" type="com.innerpeace.themoonha.domain.lesson.dto.LessonListResponse">
+    <resultMap id="LessonListMap" type="com.innerpeace.themoonha.domain.lesson.dto.LessonListDTO">
         <result property="branchName" column="branch_name"/>
-
         <collection property="lessonList" ofType="com.innerpeace.themoonha.domain.lesson.dto.LessonDTO">
             <id property="lessonId" column="lesson_id"/>
             <result property="thumbnailUrl" column="lesson_thumbnail_url"/>
@@ -32,19 +31,12 @@
             <result property="tutorName" column="tutor_name"/>
             <result property="lessonTime" column="lesson_time"/>
         </collection>
-
-        <collection property="shortFormList" ofType="com.innerpeace.themoonha.domain.lesson.dto.ShortFormDTO">
-            <id property="shortFormId" column="short_form_id"/>
-            <result property="name" column="short_form_name"/>
-            <result property="thumbnailUrl" column="short_form_thumbnail_url"/>
-            <result property="target" column="target" />
-        </collection>
     </resultMap>
 
     <select id="selectLessonList"
             parameterType="com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest"
-            resultMap="LessonListResponseMap">
-        select
+            resultMap="LessonListMap">
+        SELECT
             b.name branch_name,
             l.lesson_id,
             l.thumbnail_url lesson_thumbnail_url,
@@ -53,34 +45,23 @@
             l.cnt,
             l.cost,
             m.name tutor_name,
-            sf.short_form_id,
-            sf.name short_form_name,
-            sf.thumbnail_url short_form_thumbnail_url,
             CASE
             WHEN l.cnt = 1 THEN l.start_date || ' ' || l.start_time || '~' || l.end_time
             ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
             END AS  lesson_time
-        from
+        FROM
             lesson l
-        join
+        JOIN
             branch b
-        on
+        ON
             l.branch_id = b.branch_id
-        join
+        JOIN
             member m
-        on
+        ON
             l.member_id = m.member_id
-        join
-            category c
-        on
-            l.category_id = c.category_id
-        join
-            short_form sf
-        on
-            l.lesson_id = sf.lesson_id
         <where>
-            <if test="branchName != null and branchName != ''">
-                b.name = #{branchName}
+            <if test="branchId != null">
+                b.branch_id = #{branchId}
             </if>
 
             <if test="lessonTitle != null and lessonTitle != ''">
@@ -99,8 +80,8 @@
                 and l.target = #{target}
             </if>
 
-            <if test="category != null and category != ''">
-                and c.category = #{category}
+            <if test="categoryId != null">
+                and c.category_id = #{categoryId}
             </if>
 
             <if test="startTime != null and startTime != ''">
@@ -125,6 +106,24 @@
                 </choose>
             </if>
         </where>
+    </select>
+
+    <select id="selectShortFormList"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.ShortFormDTO">
+        SELECT
+            s.short_form_id,
+            s.name,
+            s.thumbnail_url,
+            l.target
+        FROM
+            short_form s
+        JOIN
+            lesson l
+        ON
+            s.lesson_id = l.lesson_id
+        WHERE
+            s.deleted_at IS NULL AND
+            s.expire_date > sysdate
     </select>
 
     <select id="selectLessonDetail"

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -81,7 +81,7 @@
             </if>
 
             <if test="categoryId != null">
-                and c.category_id = #{categoryId}
+                and l.category_id = #{categoryId}
             </if>
 
             <if test="startTime != null and startTime != ''">

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -20,7 +20,7 @@
 <mapper namespace="com.innerpeace.themoonha.domain.lesson.mapper.LessonMapper">
 
     <resultMap id="LessonListMap" type="com.innerpeace.themoonha.domain.lesson.dto.LessonListDTO">
-        <result property="branchName" column="branch_name"/>
+        <result property="branchId" column="branch_id"/>
         <collection property="lessonList" ofType="com.innerpeace.themoonha.domain.lesson.dto.LessonDTO">
             <id property="lessonId" column="lesson_id"/>
             <result property="thumbnailUrl" column="lesson_thumbnail_url"/>
@@ -37,7 +37,7 @@
             parameterType="com.innerpeace.themoonha.domain.lesson.dto.LessonListRequest"
             resultMap="LessonListMap">
         SELECT
-            b.name branch_name,
+            l.branch_id,
             l.lesson_id,
             l.thumbnail_url lesson_thumbnail_url,
             l.target,
@@ -52,16 +52,12 @@
         FROM
             lesson l
         JOIN
-            branch b
-        ON
-            l.branch_id = b.branch_id
-        JOIN
             member m
         ON
             l.member_id = m.member_id
         <where>
             <if test="branchId != null">
-                b.branch_id = #{branchId}
+                l.branch_id = #{branchId}
             </if>
 
             <if test="lessonTitle != null and lessonTitle != ''">


### PR DESCRIPTION
# 💡 PR 요약
- 기존에 강좌와 연관된 숏폼을 불러오는 방식에서, 따로 불러오는 방식으로 변경
- id로 조회하여 불필요한 join 제거

## ⭐️ 관련 이슈
- closes : #59 

## 📍 작업한 내용
- LessonMapper.xml 쿼리 수정
- LessonRequest DTO 객체 필드 수정

## 🔎 결과 및 이슈 공유
![image](https://github.com/user-attachments/assets/3682e172-1d4c-4951-95e1-b89990ca04db)




## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
