### PR TITLE
[ADMIN] [KAN-14] 숏폼 조회 API 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminShortFormController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminShortFormController.java
@@ -2,6 +2,7 @@ package com.innerpeace.themoonha.domain.admin.controller;
 
 import com.innerpeace.themoonha.domain.admin.dto.LessonAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.LessonListAdminRequest;
+import com.innerpeace.themoonha.domain.admin.dto.ShortFormListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.ShortFormRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.service.AdminShortFormService;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
@@ -10,8 +11,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,4 +34,13 @@ public class AdminShortFormController {
 
         return ResponseEntity.ok(CommonResponse.from(SuccessCode.ADMIN_SHORTFROM_REGISTER_SUCCESS.getMessage()));
     }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<ShortFormListAdminResponse>> ShortFormList(@RequestParam(value = "branchId", required = false) Long branchId,
+                                                                          @RequestParam(value = "expiredYn") int expiredYn){
+        log.info("/admin/shortform/list  : {}, {} ", branchId, expiredYn);
+        List<ShortFormListAdminResponse> shortFormList =  adminShortFormService.findShortFormList(branchId, expiredYn);
+        return ResponseEntity.ok(shortFormList);
+    }
+
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminShortFormController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminShortFormController.java
@@ -19,6 +19,19 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 어드민 숏폼 관리 컨트롤러
+ * @author 최유경
+ * @since 2024.08.29
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.29  	최유경       최초 생성
+ * 2024.08.30   최유경       어드민 숏폼 조회
+ * </pre>
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/shortform")

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormListAdminResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormListAdminResponse.java
@@ -1,0 +1,29 @@
+package com.innerpeace.themoonha.domain.admin.dto;
+
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class ShortFormListAdminResponse {
+    private Long shortFormId;
+    private String name;
+    private String videoUrl;
+    private Date startDate;
+    private Date expireDate;
+    private Date createdAt;
+    private Long lessonId;
+    private Long branchId;
+    private String branchName;
+    private Long memberId;
+    private String tutorName;
+    private String title;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormListAdminResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormListAdminResponse.java
@@ -8,6 +8,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * 어드민 숏폼 조회 응답 dto
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormRegisterAdminRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormRegisterAdminRequest.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 import lombok.ToString;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormRegisterAdminRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/ShortFormRegisterAdminRequest.java
@@ -7,6 +7,18 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * 어드민 숏폼 등록 요청 dto
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.java
@@ -6,6 +6,19 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+/**
+ * 어드민 숏폼 관리 매퍼
+ * @author 최유경
+ * @since 2024.08.29
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.29  	최유경       최초 생성
+ * 2024.08.30   최유경       숏폼 조회
+ * </pre>
+ */
 @Mapper
 public interface AdminShortFormMapper {
     int insertShortForm(@Param("registerRequest") ShortFormRegisterAdminRequest registerAdminRequest,

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.java
@@ -1,6 +1,8 @@
 package com.innerpeace.themoonha.domain.admin.mapper;
 
+import com.innerpeace.themoonha.domain.admin.dto.ShortFormListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.ShortFormRegisterAdminRequest;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -8,4 +10,7 @@ import org.apache.ibatis.annotations.Param;
 public interface AdminShortFormMapper {
     int insertShortForm(@Param("registerRequest") ShortFormRegisterAdminRequest registerAdminRequest,
                         @Param("shortFormVideoS3Url") String shortFormVideoS3Url);
+
+    List<ShortFormListAdminResponse> selectShortFormList(@Param("branchId") Long branchId,
+                                                         @Param("expiredYn") int expiredYn);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormService.java
@@ -1,8 +1,12 @@
 package com.innerpeace.themoonha.domain.admin.service;
 
+import com.innerpeace.themoonha.domain.admin.dto.ShortFormListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.ShortFormRegisterAdminRequest;
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AdminShortFormService {
     void addShortForm(ShortFormRegisterAdminRequest shortFormRegisterAdminRequest, MultipartFile shortFormVideoFile);
+
+    List<ShortFormListAdminResponse> findShortFormList(Long branchId, int expiredYn);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormService.java
@@ -5,6 +5,19 @@ import com.innerpeace.themoonha.domain.admin.dto.ShortFormRegisterAdminRequest;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 어드민 숏폼 관리 서비스
+ * @author 최유경
+ * @since 2024.08.29
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.29  	최유경       최초 생성
+ * 2024.08.30   최유경       숏폼 조회
+ * </pre>
+ */
 public interface AdminShortFormService {
     void addShortForm(ShortFormRegisterAdminRequest shortFormRegisterAdminRequest, MultipartFile shortFormVideoFile);
 

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormServiceImpl.java
@@ -15,6 +15,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 어드민 숏폼 관리 서비스 구현체
+ * @author 최유경
+ * @since 2024.08.29
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.29  	최유경       최초 생성
+ * 2024.08.30   최유경       숏폼 조회
+ * </pre>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormServiceImpl.java
@@ -1,5 +1,6 @@
 package com.innerpeace.themoonha.domain.admin.service;
 
+import com.innerpeace.themoonha.domain.admin.dto.ShortFormListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.ShortFormRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.mapper.AdminLessonMapper;
 import com.innerpeace.themoonha.domain.admin.mapper.AdminShortFormMapper;
@@ -7,6 +8,7 @@ import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
 import com.innerpeace.themoonha.global.service.S3Service;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,5 +38,10 @@ public class AdminShortFormServiceImpl implements AdminShortFormService {
         } catch (IOException e){
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Override
+    public List<ShortFormListAdminResponse> findShortFormList(Long branchId, int expiredYn) {
+        return adminShortFormMapper.selectShortFormList(branchId, expiredYn);
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminShortFormServiceImpl.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -20,6 +21,7 @@ public class AdminShortFormServiceImpl implements AdminShortFormService {
     private final S3Service s3Service;
 
     @Override
+    @Transactional
     public void addShortForm(ShortFormRegisterAdminRequest shortFormRegisterAdminRequest, MultipartFile shortFormVideoFile) {
         try{
             // S3에 업로드

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.xml
@@ -3,15 +3,16 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <!--
- * 어드민 강좌 매퍼 XML
+ * 어드민 숏폼 매퍼 XML
  * @author 최유경
- * @since 2024.08.28
+ * @since 2024.08.29
  * @version 1.0
  *
  * <pre>
  * 수정일        	수정자        수정내용
  * ==========  =========    =========
- * 2024.08.28  	최유경        최초 생성
+ * 2024.08.29  	최유경        최초 생성
+ * 2024.08.30  	최유경        숏폼 조회
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.admin.mapper.AdminShortFormMapper">

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminShortFormMapper.xml
@@ -27,4 +27,54 @@
                 #{registerRequest.expireDate})
         ]]>
     </insert>
+
+    <select id="selectShortFormList" resultType="com.innerpeace.themoonha.domain.admin.dto.ShortFormListAdminResponse">
+
+            SELECT
+                sf.short_form_id,
+                sf.lesson_id,
+                sf.name,
+                sf.video_url,
+                sf.start_date,
+                sf.expire_date,
+                sf.created_at,
+                l.branch_id,
+                b.name branch_name,
+                l.member_id,
+                m.name tutor_name,
+                l.title
+            FROM
+                short_form sf
+                JOIN
+                lesson l
+                ON sf.lesson_id = l.lesson_id
+                JOIN
+                branch b
+                ON
+                l.branch_id = b.branch_id
+                JOIN
+                member m
+                ON
+                l.member_id = m.member_id
+            <where>
+                sf.deleted_at IS NULL
+                AND l.deleted_at IS NULL
+                <if test="branchId != null">
+                    AND l.branch_id = #{branchId}
+                </if>
+
+                <if test="expiredYn != null">
+                    AND expire_date
+                    <choose>
+                        <when test="expiredYn == 0">
+                            > SYSDATE
+                        </when>
+                        <when test="expiredYn == 1">
+                            <![CDATA[<= SYSDATE]]>
+                        </when>
+                    </choose>
+                </if>
+            </where>
+
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
숏폼 조회 API 구현했습니다.

## ⭐️ 관련 이슈
- closes : #63 

## 📍 작업한 내용
- 숏폼 조회 API
- 지점별로 조회, 진행중/만료 숏폼 구분 검색

## 🔎 결과 및 이슈 공유
- 진행중
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/f22893b9-f910-46e5-967a-de74b4c995db">

- 만료된
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/66eeeabf-3e32-4e85-bf3d-f8aca984f6b5">

- 지점 + 진행
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/46fa48fb-192c-4d5d-8d10-f1b37712a933">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
