### PR TITLE
[ADMIN] [KAN-16] 문화공방 프롤로그 테마 및 영상 등록, 조회

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
@@ -4,6 +4,7 @@ import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.service.AdminCraftService;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
 import com.innerpeace.themoonha.global.vo.SuccessCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +23,8 @@ public class AdminCraftController {
 
     @PostMapping("/prologue/register")
     public ResponseEntity<CommonResponse> PrologueAdd(@RequestPart("registerRequest") PrologueRegisterAdminRequest registerAdminRequest,
-                                                      @RequestPart("thumbnailFile") MultipartFile thumbnailFile,
-                                                      @RequestPart("prologueVideoFile")MultipartFile prologueVideoFile){
+                                                      @RequestPart("thumbnailFile") List<MultipartFile> thumbnailFile,
+                                                      @RequestPart("prologueVideoFile")List<MultipartFile> prologueVideoFile){
         adminCraftService.addPrologue(registerAdminRequest, thumbnailFile, prologueVideoFile);
 
         return ResponseEntity.ok(CommonResponse.from(SuccessCode.ADMIN_PROLOGUE_REGISTER_SUCCESS.getMessage()));

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
@@ -1,5 +1,6 @@
 package com.innerpeace.themoonha.domain.admin.controller;
 
+import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.service.AdminCraftService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -47,7 +49,13 @@ public class AdminCraftController {
 
     @GetMapping("/prologue/theme/list")
     public ResponseEntity<List<PrologueThemeListAdminResponse>> PrologueThemeList(){
-        List<PrologueThemeListAdminResponse> prologueThemeList = adminCraftService.findPrologueList();
+        List<PrologueThemeListAdminResponse> prologueThemeList = adminCraftService.findPrologueThemeList();
         return ResponseEntity.ok(prologueThemeList);
+    }
+
+    @GetMapping("/prologue/theme/{prologueThemeId}")
+    public ResponseEntity<List<PrologueListAdminResponse>> PrologueThemeList(@PathVariable Long prologueThemeId){
+        List<PrologueListAdminResponse> prologueList = adminCraftService.findPrologueList(prologueThemeId);
+        return ResponseEntity.ok(prologueList);
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.admin.controller;
 
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.service.AdminCraftService;
 import com.innerpeace.themoonha.global.dto.CommonResponse;
 import com.innerpeace.themoonha.global.vo.SuccessCode;
@@ -8,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -41,5 +43,11 @@ public class AdminCraftController {
         adminCraftService.addPrologue(registerAdminRequest, thumbnailFile, prologueVideoFile);
 
         return ResponseEntity.ok(CommonResponse.from(SuccessCode.ADMIN_PROLOGUE_REGISTER_SUCCESS.getMessage()));
+    }
+
+    @GetMapping("/prologue/theme/list")
+    public ResponseEntity<List<PrologueThemeListAdminResponse>> PrologueThemeList(){
+        List<PrologueThemeListAdminResponse> prologueThemeList = adminCraftService.findPrologueList();
+        return ResponseEntity.ok(prologueThemeList);
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
@@ -38,6 +38,14 @@ import org.springframework.web.multipart.MultipartFile;
 public class AdminCraftController {
     private final AdminCraftService adminCraftService;
 
+    /**
+     * 테마 및 프롤로그 등록
+     *
+     * @param registerAdminRequest 테마 정보
+     * @param thumbnailFile 영상 썸네일 사진 리스트
+     * @param prologueVideoFile 영상 파일 리스
+     * @return
+     */
     @PostMapping("/prologue/register")
     public ResponseEntity<CommonResponse> PrologueAdd(@RequestPart("registerRequest") PrologueRegisterAdminRequest registerAdminRequest,
                                                       @RequestPart("thumbnailFile") List<MultipartFile> thumbnailFile,
@@ -47,12 +55,23 @@ public class AdminCraftController {
         return ResponseEntity.ok(CommonResponse.from(SuccessCode.ADMIN_PROLOGUE_REGISTER_SUCCESS.getMessage()));
     }
 
+    /**
+     * 테마 전체 조회
+     *
+     * @return 테마 리스트
+     */
     @GetMapping("/prologue/theme/list")
     public ResponseEntity<List<PrologueThemeListAdminResponse>> PrologueThemeList(){
         List<PrologueThemeListAdminResponse> prologueThemeList = adminCraftService.findPrologueThemeList();
         return ResponseEntity.ok(prologueThemeList);
     }
 
+    /**
+     * 테마별 프롤로그 조회
+     *
+     * @param prologueThemeId 테마 ID
+     * @return 프롤로그 리스트
+     */
     @GetMapping("/prologue/theme/{prologueThemeId}")
     public ResponseEntity<List<PrologueListAdminResponse>> PrologueThemeList(@PathVariable Long prologueThemeId){
         List<PrologueListAdminResponse> prologueList = adminCraftService.findPrologueList(prologueThemeId);

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
@@ -1,0 +1,31 @@
+package com.innerpeace.themoonha.domain.admin.controller;
+
+import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import com.innerpeace.themoonha.domain.admin.service.AdminCraftService;
+import com.innerpeace.themoonha.global.dto.CommonResponse;
+import com.innerpeace.themoonha.global.vo.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/admin/craft")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminCraftController {
+    private final AdminCraftService adminCraftService;
+
+    @PostMapping("/prologue/register")
+    public ResponseEntity<CommonResponse> PrologueAdd(@RequestPart("registerRequest") PrologueRegisterAdminRequest registerAdminRequest,
+                                                      @RequestPart("thumbnailFile") MultipartFile thumbnailFile,
+                                                      @RequestPart("prologueVideoFile")MultipartFile prologueVideoFile){
+        adminCraftService.addPrologue(registerAdminRequest, thumbnailFile, prologueVideoFile);
+
+        return ResponseEntity.ok(CommonResponse.from(SuccessCode.ADMIN_PROLOGUE_REGISTER_SUCCESS.getMessage()));
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminCraftController.java
@@ -14,6 +14,19 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 어드민 문화공방 관리 컨트롤러
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * 2024.08.31   최유경       프롤로그 테마 기획 변경
+ * </pre>
+ */
 @RestController
 @RequestMapping("/admin/craft")
 @RequiredArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminShortFormController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/controller/AdminShortFormController.java
@@ -1,7 +1,5 @@
 package com.innerpeace.themoonha.domain.admin.controller;
 
-import com.innerpeace.themoonha.domain.admin.dto.LessonAdminResponse;
-import com.innerpeace.themoonha.domain.admin.dto.LessonListAdminRequest;
 import com.innerpeace.themoonha.domain.admin.dto.ShortFormListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.ShortFormRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.service.AdminShortFormService;

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueListAdminResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueListAdminResponse.java
@@ -1,0 +1,22 @@
+package com.innerpeace.themoonha.domain.admin.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PrologueListAdminResponse {
+    private Long prologueId;
+    private String title;
+    private String videoUrl;
+    private Date createdAt;
+    private String thumbnailUrl;
+    private int type;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueRegisterAdminRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueRegisterAdminRequest.java
@@ -8,6 +8,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+/**
+ * 어드민 프롤로그 등록 요청 dto
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * </pre>
+ */
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueRegisterAdminRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueRegisterAdminRequest.java
@@ -1,5 +1,7 @@
 package com.innerpeace.themoonha.domain.admin.dto;
 
+import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +14,11 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class PrologueRegisterAdminRequest {
-    private String title;
-    private int type;
+    private String name;
+    private Long memberId;
+    private String description;
+    private int videoCnt;
+    private Date startDate;
+    private Date expireDate;
+    List<String> prologueList;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueRegisterAdminRequest.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueRegisterAdminRequest.java
@@ -1,0 +1,17 @@
+package com.innerpeace.themoonha.domain.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PrologueRegisterAdminRequest {
+    private String title;
+    private int type;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueThemeListAdminResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/dto/PrologueThemeListAdminResponse.java
@@ -1,0 +1,25 @@
+package com.innerpeace.themoonha.domain.admin.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PrologueThemeListAdminResponse {
+    private Long prologueThemeId;
+    private Long memberId;
+    private String writer;
+    private String name;
+    private String description;
+    private int videoCnt;
+    private String period;
+    private String latestUpdateDate;
+    private String themeStatus;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
@@ -1,0 +1,16 @@
+package com.innerpeace.themoonha.domain.admin.mapper;
+
+import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface AdminCraftMapper {
+
+    void insertPrologue(@Param("registerRequest")PrologueRegisterAdminRequest registerAdminRequest,
+                        @Param("thumbnailS3Url") String thumbnailS3Url,
+                        @Param("prologueS3Url") String prologueS3Url);
+
+    void selectPrologueList();
+
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.admin.mapper;
 
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -8,8 +9,8 @@ import org.apache.ibatis.annotations.Param;
 public interface AdminCraftMapper {
 
     void insertPrologue(@Param("registerRequest")PrologueRegisterAdminRequest registerAdminRequest,
-                        @Param("thumbnailS3Url") String thumbnailS3Url,
-                        @Param("prologueS3Url") String prologueS3Url);
+                        @Param("thumbnailS3Url") List<String> thumbnailS3Url,
+                        @Param("prologueS3Url") List<String> prologueS3Url);
 
     void selectPrologueList();
 

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.admin.mapper;
 
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -25,6 +26,6 @@ public interface AdminCraftMapper {
                         @Param("thumbnailS3Url") List<String> thumbnailS3Url,
                         @Param("prologueS3Url") List<String> prologueS3Url);
 
-    void selectPrologueList();
+    List<PrologueThemeListAdminResponse> selectPrologueThemeList();
 
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
@@ -1,10 +1,12 @@
 package com.innerpeace.themoonha.domain.admin.mapper;
 
+import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.security.core.parameters.P;
 
 /**
  * 어드민 문화공방 관리 매퍼
@@ -27,5 +29,7 @@ public interface AdminCraftMapper {
                         @Param("prologueS3Url") List<String> prologueS3Url);
 
     List<PrologueThemeListAdminResponse> selectPrologueThemeList();
+
+    List<PrologueListAdminResponse> selectPrologueListByTheme(@Param("prologueThemeId") Long prologueThemeId);
 
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.java
@@ -5,6 +5,19 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+/**
+ * 어드민 문화공방 관리 매퍼
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * 2024.08.31   최유경       프롤로그 테마 기획 변경
+ * </pre>
+ */
 @Mapper
 public interface AdminCraftMapper {
 

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
@@ -1,0 +1,16 @@
+package com.innerpeace.themoonha.domain.admin.service;
+
+import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
+import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AdminCraftService {
+
+    void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,
+                     MultipartFile thumbnailFile,
+                     MultipartFile prologueVideoFil);
+
+    List<PrologueListAdminResponse> findPrologueList();
+
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
@@ -2,6 +2,7 @@ package com.innerpeace.themoonha.domain.admin.service;
 
 import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,6 +25,6 @@ public interface AdminCraftService {
                      List<MultipartFile> thumbnailFile,
                      List<MultipartFile> prologueVideoFil);
 
-    List<PrologueListAdminResponse> findPrologueList();
+    List<PrologueThemeListAdminResponse> findPrologueList();
 
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
@@ -21,11 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
  */
 public interface AdminCraftService {
 
+    /**
+     * 테마 및 프롤로그 등록
+     *
+     * @param prologueRegisterAdminRequest 테마 정보
+     * @param thumbnailFile 썸네일 사진 리스트
+     * @param prologueVideoFil 영상 파일 리스트
+     */
     void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,
                      List<MultipartFile> thumbnailFile,
                      List<MultipartFile> prologueVideoFil);
 
+    /**
+     * 테마 조회
+     *
+     * @return 테마 리스트
+     */
     List<PrologueThemeListAdminResponse> findPrologueThemeList();
 
+    /**
+     * 테마별 프롤로그 조회
+     * @param prologueThemeId 테마 ID
+     * @return 테마별 프롤로그 리스트
+     */
     List<PrologueListAdminResponse> findPrologueList(Long prologueThemeId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
@@ -8,8 +8,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface AdminCraftService {
 
     void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,
-                     MultipartFile thumbnailFile,
-                     MultipartFile prologueVideoFil);
+                     List<MultipartFile> thumbnailFile,
+                     List<MultipartFile> prologueVideoFil);
 
     List<PrologueListAdminResponse> findPrologueList();
 

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
@@ -25,6 +25,7 @@ public interface AdminCraftService {
                      List<MultipartFile> thumbnailFile,
                      List<MultipartFile> prologueVideoFil);
 
-    List<PrologueThemeListAdminResponse> findPrologueList();
+    List<PrologueThemeListAdminResponse> findPrologueThemeList();
 
+    List<PrologueListAdminResponse> findPrologueList(Long prologueThemeId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftService.java
@@ -5,6 +5,19 @@ import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 어드민 문화공방 관리 서비스
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * 2024.08.31   최유경       프롤로그 테마 기획 변경
+ * </pre>
+ */
 public interface AdminCraftService {
 
     void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
@@ -50,7 +50,13 @@ public class AdminCraftServiceImpl implements AdminCraftService{
     }
 
     @Override
-    public List<PrologueThemeListAdminResponse> findPrologueList() {
+    public List<PrologueThemeListAdminResponse> findPrologueThemeList() {
         return adminCraftMapper.selectPrologueThemeList();
+    }
+
+
+    @Override
+    public List<PrologueListAdminResponse> findPrologueList(Long prologueThemeId) {
+        return adminCraftMapper.selectPrologueListByTheme(prologueThemeId);
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
@@ -1,0 +1,45 @@
+package com.innerpeace.themoonha.domain.admin.service;
+
+import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
+import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import com.innerpeace.themoonha.domain.admin.mapper.AdminCraftMapper;
+import com.innerpeace.themoonha.global.exception.CustomException;
+import com.innerpeace.themoonha.global.exception.ErrorCode;
+import com.innerpeace.themoonha.global.service.S3Service;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminCraftServiceImpl implements AdminCraftService{
+    private final AdminCraftMapper adminCraftMapper;
+    private final S3Service s3Service;
+
+    @Override
+    @Transactional
+    public void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,
+                            MultipartFile thumbnailFile,
+                            MultipartFile prologueVideoFil) {
+        try{
+            // S3에 업로드
+            String thumbnailS3Url = s3Service.saveFile(thumbnailFile, "craft");
+            String prologueS3Url = s3Service.saveFile(prologueVideoFil, "craft");
+
+            // 데이터베이스 저장
+            adminCraftMapper.insertPrologue(prologueRegisterAdminRequest, thumbnailS3Url, prologueS3Url);
+        } catch (IOException e){
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public List<PrologueListAdminResponse> findPrologueList() {
+        return null;
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
@@ -24,18 +24,18 @@ public class AdminCraftServiceImpl implements AdminCraftService{
     @Override
     @Transactional
     public void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,
-                            MultipartFile thumbnailFile,
-                            MultipartFile prologueVideoFil) {
-        try{
-            // S3에 업로드
-            String thumbnailS3Url = s3Service.saveFile(thumbnailFile, "craft");
-            String prologueS3Url = s3Service.saveFile(prologueVideoFil, "craft");
+                            List<MultipartFile> thumbnailFile,
+                            List<MultipartFile> prologueVideoFil) {
 
-            // 데이터베이스 저장
-            adminCraftMapper.insertPrologue(prologueRegisterAdminRequest, thumbnailS3Url, prologueS3Url);
-        } catch (IOException e){
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+        // S3에 업로드
+        List<String> thumbnailS3Url = s3Service.saveFiles(thumbnailFile, "craft");
+        List<String> prologueS3Url = s3Service.saveFiles(prologueVideoFil, "craft");
+
+        // 데이터베이스 저장
+        adminCraftMapper.insertPrologue(prologueRegisterAdminRequest,
+                thumbnailS3Url,
+                prologueS3Url);
+
     }
 
     @Override

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
@@ -2,6 +2,7 @@ package com.innerpeace.themoonha.domain.admin.service;
 
 import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
+import com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.mapper.AdminCraftMapper;
 import com.innerpeace.themoonha.global.service.S3Service;
 import java.util.List;
@@ -49,7 +50,7 @@ public class AdminCraftServiceImpl implements AdminCraftService{
     }
 
     @Override
-    public List<PrologueListAdminResponse> findPrologueList() {
-        return null;
+    public List<PrologueThemeListAdminResponse> findPrologueList() {
+        return adminCraftMapper.selectPrologueThemeList();
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
@@ -32,6 +32,13 @@ public class AdminCraftServiceImpl implements AdminCraftService{
     private final AdminCraftMapper adminCraftMapper;
     private final S3Service s3Service;
 
+    /**
+     * 테마 및 프롤로그 등록
+     *
+     * @param prologueRegisterAdminRequest 테마 정보
+     * @param thumbnailFile 썸네일 사진 리스트
+     * @param prologueVideoFil 영상 파일 리스트
+     */
     @Override
     @Transactional
     public void addPrologue(PrologueRegisterAdminRequest prologueRegisterAdminRequest,
@@ -46,15 +53,24 @@ public class AdminCraftServiceImpl implements AdminCraftService{
         adminCraftMapper.insertPrologue(prologueRegisterAdminRequest,
                 thumbnailS3Url,
                 prologueS3Url);
-
     }
 
+    /**
+     * 테마 조회
+     *
+     * @return 테마 리스트
+     */
     @Override
     public List<PrologueThemeListAdminResponse> findPrologueThemeList() {
         return adminCraftMapper.selectPrologueThemeList();
     }
 
 
+    /**
+     * 테마별 프롤로그 조회
+     * @param prologueThemeId 테마 ID
+     * @return 테마별 프롤로그 리스트
+     */
     @Override
     public List<PrologueListAdminResponse> findPrologueList(Long prologueThemeId) {
         return adminCraftMapper.selectPrologueListByTheme(prologueThemeId);

--- a/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/admin/service/AdminCraftServiceImpl.java
@@ -3,10 +3,7 @@ package com.innerpeace.themoonha.domain.admin.service;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse;
 import com.innerpeace.themoonha.domain.admin.dto.PrologueRegisterAdminRequest;
 import com.innerpeace.themoonha.domain.admin.mapper.AdminCraftMapper;
-import com.innerpeace.themoonha.global.exception.CustomException;
-import com.innerpeace.themoonha.global.exception.ErrorCode;
 import com.innerpeace.themoonha.global.service.S3Service;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +11,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 어드민 문화공방 관리 서비스 구현체
+ * @author 최유경
+ * @since 2024.08.30
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.30  	최유경       최초 생성
+ * 2024.08.31   최유경       프롤로그 테마 기획 변경
+ * </pre>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/innerpeace/themoonha/global/entity/Prologue.java
+++ b/src/main/java/com/innerpeace/themoonha/global/entity/Prologue.java
@@ -1,4 +1,4 @@
-package com.innerpeace.themoonha.domain.admin.dto;
+package com.innerpeace.themoonha.global.entity;
 
 import java.util.Date;
 import lombok.AllArgsConstructor;
@@ -7,16 +7,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 @ToString
-public class PrologueListAdminResponse {
+public class Prologue {
     private Long prologueId;
     private Long prologueThemeId;
     private String title;
     private String videoUrl;
-    private Date latestUpdateDate;
+    private Date createdAt;
+    private Date updatedAt;
+    private Date deletedAt;
     private String thumbnailUrl;
-    private int likeCnt;
 }

--- a/src/main/java/com/innerpeace/themoonha/global/handler/StringListTypeHandler.java
+++ b/src/main/java/com/innerpeace/themoonha/global/handler/StringListTypeHandler.java
@@ -1,0 +1,43 @@
+package com.innerpeace.themoonha.global.handler;
+
+import java.sql.Array;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+public class StringListTypeHandler extends BaseTypeHandler<List<String>> {
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, List<String> strings, JdbcType jdbcType)
+            throws SQLException {
+        Connection conn = ps.getConnection();
+        // 리스트를 배열로 변환
+        String[] stringArray = strings.toArray(new String[0]);
+
+        // Oracle의 커스텀 타입으로 배열 생성
+        Array oracleArray = conn.unwrap(oracle.jdbc.OracleConnection.class)
+                .createOracleArray("VARCHAR2_TABLE", stringArray);
+
+        // PreparedStatement에 배열을 설정
+        ps.setArray(i, oracleArray);
+    }
+
+    @Override
+    public List<String> getNullableResult(ResultSet rs, String s) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public List<String> getNullableResult(ResultSet rs, int i) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public List<String> getNullableResult(CallableStatement cs, int i) throws SQLException {
+        return null;
+    }
+}

--- a/src/main/java/com/innerpeace/themoonha/global/handler/StringListTypeHandler.java
+++ b/src/main/java/com/innerpeace/themoonha/global/handler/StringListTypeHandler.java
@@ -10,6 +10,18 @@ import java.util.List;
 import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 
+/**
+ * List & 오라클 Array 타입 호환 핸들러
+ * @author 최유경
+ * @since 2024.08.31
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.31  	최유경       최초 생성
+ * </pre>
+ */
 public class StringListTypeHandler extends BaseTypeHandler<List<String>> {
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, List<String> strings, JdbcType jdbcType)

--- a/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
+++ b/src/main/java/com/innerpeace/themoonha/global/vo/SuccessCode.java
@@ -23,7 +23,8 @@ public enum SuccessCode {
     LOUNGE_COMMENT_UPDATE_SUCCESS(200, "라운지 댓글이 수정되었습니다."),
     LOUNGE_COMMENT_DELETE_SUCCESS(200, "라운지 댓글이 삭제되었습니다."),
     ATTENDANCE_START_SUCCESS(200, "출석 시작에 성공하였습니다."),
-    ATTENDANCE_UPDATE_SUCCESS(200, "출석 정보 수정에 성공하였습니다.");
+    ATTENDANCE_UPDATE_SUCCESS(200, "출석 정보 수정에 성공하였습니다."),
+    ADMIN_PROLOGUE_REGISTER_SUCCESS(200, "프롤로그 등록에 성공하였습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
@@ -30,4 +30,32 @@
                 #{prologueS3Url, mode=IN, jdbcTypeName=VARCHAR2_TABLE, typeHandler=com.innerpeace.themoonha.global.handler.StringListTypeHandler}
             )
     </insert>
+
+    <select id="selectPrologueThemeList" resultType="com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse">
+        <![CDATA[
+        SELECT
+            pt.prologue_theme_id,
+            pt.member_id,
+            m.name AS writer,
+            pt.name,
+            pt.description,
+            pt.video_cnt,
+            TO_CHAR(pt.start_date, 'YYYY-MM-DD') || ' ~ ' ||  TO_CHAR(pt.expire_date, 'YYYY-MM-DD') AS period,
+            NVL2(pt.updated_at, pt.updated_at, pt.created_at) AS latest_update_date,
+            CASE
+                WHEN pt.start_date <= SYSDATE AND SYSDATE < pt.expire_date THEN '진행중'
+                WHEN pt.start_date > SYSDATE THEN '시작전'
+                ELSE '종료됨'
+            END AS theme_status
+        FROM
+            prologue_theme pt
+            JOIN
+            member m
+            ON pt.member_id = m.member_id
+        WHERE
+            pt.deleted_at IS NULL
+        ORDER BY
+            pt.created_at DESC
+        ]]>
+    </select>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
@@ -3,20 +3,21 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <!--
- * 어드민 문확 공방 관리 매퍼 XML
+ * 어드민 문화 공방 관리 매퍼 XML
  * @author 최유경
- * @since 2024.08.28
+ * @since 2024.08.30
  * @version 1.0
  *
  * <pre>
  * 수정일        	수정자        수정내용
  * ==========  =========    =========
- * 2024.08.28  	최유경        최초 생성
+ * 2024.08.30  	최유경        최초 생성
+ * 2024.08.31  	최유경        프롤로그 테마 기획 변경
  * </pre>
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.admin.mapper.AdminCraftMapper">
 
-
+    <!-- 테마 등록 및 프롤로그 등록 -->
     <insert id="insertPrologue">
         CALL insert_prologue_theme_and_prologue(
                 #{registerRequest.memberId, mode=IN, jdbcType=NUMERIC},
@@ -31,6 +32,7 @@
             )
     </insert>
 
+    <!-- 테마 조회 -->
     <select id="selectPrologueThemeList" resultType="com.innerpeace.themoonha.domain.admin.dto.PrologueThemeListAdminResponse">
         <![CDATA[
         SELECT
@@ -59,7 +61,7 @@
         ]]>
     </select>
 
-
+    <!-- 프롤로그 조회 -->
     <select id="selectPrologueListByTheme" resultType="com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse">
         SELECT
             p.prologue_id,

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
@@ -16,14 +16,18 @@
  -->
 <mapper namespace="com.innerpeace.themoonha.domain.admin.mapper.AdminCraftMapper">
 
+
     <insert id="insertPrologue">
-        <![CDATA[
-        insert into prologue (prologue_id, title, video_url, thumbnail_url, type)
-        values (prologue_seq.nextval,
-                #{registerRequest.title},
-                #{prologueS3Url},
-                #{thumbnailS3Url},
-                #{registerRequest.type})
-        ]]>
+        CALL insert_prologue_theme_and_prologue(
+                #{registerRequest.memberId, mode=IN, jdbcType=NUMERIC},
+                #{registerRequest.name, mode=IN, jdbcType=VARCHAR},
+                #{registerRequest.description, mode=IN, jdbcType=VARCHAR},
+                #{registerRequest.videoCnt, mode=IN, jdbcType=NUMERIC},
+                #{registerRequest.startDate, mode=IN, jdbcType=DATE},
+                #{registerRequest.expireDate, mode=IN, jdbcType=DATE},
+                #{registerRequest.prologueList, mode=IN, jdbcTypeName=VARCHAR2_TABLE, typeHandler=com.innerpeace.themoonha.global.handler.StringListTypeHandler},
+                #{thumbnailS3Url, mode=IN, jdbcTypeName=VARCHAR2_TABLE, typeHandler=com.innerpeace.themoonha.global.handler.StringListTypeHandler},
+                #{prologueS3Url, mode=IN, jdbcTypeName=VARCHAR2_TABLE, typeHandler=com.innerpeace.themoonha.global.handler.StringListTypeHandler}
+            )
     </insert>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
@@ -58,4 +58,29 @@
             pt.created_at DESC
         ]]>
     </select>
+
+
+    <select id="selectPrologueListByTheme" resultType="com.innerpeace.themoonha.domain.admin.dto.PrologueListAdminResponse">
+        SELECT
+            p.prologue_id,
+            p.prologue_theme_id,
+            p.title,
+            p.video_url,
+            NVL(p.updated_at,p.created_at) AS latest_update_date,
+            p.thumbnail_url,
+            NVL(lc.cnt,0) AS like_cnt
+        FROM
+            prologue p
+                LEFT JOIN
+            (SELECT
+                 COUNT(like_cnt_id) AS cnt,
+                 prologue_id
+             FROM like_cnt
+             WHERE prologue_id IS NOT NULL
+             GROUP BY prologue_id
+            ) lc
+            ON p.prologue_id = lc.prologue_id
+        WHERE
+            p.prologue_theme_id = #{prologueThemeId}
+    </select>
 </mapper>

--- a/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/admin/mapper/AdminCraftMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 어드민 문확 공방 관리 매퍼 XML
+ * @author 최유경
+ * @since 2024.08.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ==========  =========    =========
+ * 2024.08.28  	최유경        최초 생성
+ * </pre>
+ -->
+<mapper namespace="com.innerpeace.themoonha.domain.admin.mapper.AdminCraftMapper">
+
+    <insert id="insertPrologue">
+        <![CDATA[
+        insert into prologue (prologue_id, title, video_url, thumbnail_url, type)
+        values (prologue_seq.nextval,
+                #{registerRequest.title},
+                #{prologueS3Url},
+                #{thumbnailS3Url},
+                #{registerRequest.type})
+        ]]>
+    </insert>
+</mapper>


### PR DESCRIPTION
# 💡 PR 요약
문화공방 프롤로그 테마 및 영상 등록, 조회 구현했습니다. 
테마를 생성해야 하는 이슈를 발견해서 PROLOGUE_THEME 테이블 추가로 작성했습니다. 
PR 하나에 많은 기능 꾹꾹 눌러담았습니다!! 제송합니당

## ⭐️ 관련 이슈
- closes : #65 

## 📍 작업한 내용
- 프롤로그 테마 테이블 작성
- 테마 및 영상 등록
- 테마 조회
- 테마별 프롤로그 조회

## 🔎 결과 및 이슈 공유
- 등록
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/d9fc65f2-500e-46f0-8660-7493a069c1a5">

- 테마 조회
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/416a3e6d-7ad6-49e1-811b-83947fac5f50">

- 테마별 프롤로그 조회
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/e2316a7c-c3ff-41a5-be70-ba80f18eb74b">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
