### PR TITLE
[LESSON] [KAN-25] 비포애프터에 등록 가능한 강좌 조회 API 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/controller/LessonController.java
@@ -79,4 +79,10 @@ public class LessonController {
         Long memberId = 1L;
         return ResponseEntity.ok(lessonService.payLesson(sugangRequest.getCartIdList(), memberId));
     }
+
+    @GetMapping("/enroll")
+    public ResponseEntity<List<LessonEnrollResponse>> lessonEnrollList() {
+        Long memberId = 1L;
+        return ResponseEntity.ok(lessonService.findEnrollLessonList(memberId));
+    }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonEnrollResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/dto/LessonEnrollResponse.java
@@ -1,0 +1,14 @@
+package com.innerpeace.themoonha.domain.lesson.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LessonEnrollResponse {
+    private String lessonId;
+    private String title;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.java
@@ -32,4 +32,6 @@ public interface LessonMapper {
                    @Param("memberId") Long memberId);
     int insertSugang(@Param("cartIdList") List<Long> cartIdList,
                      @Param("memberId") Long memberId);
+
+    List<LessonEnrollResponse> selectLessonEnrollList(Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonService.java
@@ -28,4 +28,5 @@ public interface LessonService {
     List<CartResponse> findCartList(Long memberId);
     CommonResponse addCart(CartRequest cartRequest);
     CommonResponse payLesson(List<Long> cartIdList, Long memberId);
+    List<LessonEnrollResponse> findEnrollLessonList(Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lesson/service/LessonServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,6 +92,11 @@ public class LessonServiceImpl implements LessonService {
         }
 
         return CommonResponse.of(true, SuccessCode.SUGANG_APPLICATION_SUCCESS.getMessage());
+    }
+
+    @Override
+    public List<LessonEnrollResponse> findEnrollLessonList(Long memberId) {
+        return lessonMapper.selectLessonEnrollList(memberId);
     }
 
 }

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -255,4 +255,23 @@
                 #{cartId}
             </foreach>
     </update>
+
+
+    <select id="selectLessonEnrollList"
+            resultType="com.innerpeace.themoonha.domain.lesson.dto.LessonEnrollResponse">
+        SELECT
+            s.lesson_id, l.title
+        FROM
+            sugang s
+        JOIN
+            lesson l on s.lesson_id = l.lesson_id
+        LEFT JOIN
+            before_after ba on l.lesson_id = ba.lesson_id
+        WHERE
+            s.member_id = #{memberId} and
+            to_char(sysdate, 'YYYY-MM-DD') > l.end_date and
+            ba.lesson_id is null
+        ORDER BY
+            s.lesson_id
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
비포애프터에 등록 가능한 강좌 조회 API 구현

## ⭐️ 관련 이슈
- closes : #85 

## 📍 작업한 내용
- 비포애프터에 등록 가능한 강좌 조회 API 구현

## 🔎 결과 및 이슈 공유
![image](https://github.com/user-attachments/assets/319375ca-695e-4ff5-a122-5fa554d81488)



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
