### PR TITLE
[COMMON] [KAN-60] DB url 업로드 시 cloudfront url로 등록

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/global/service/S3Service.java
+++ b/src/main/java/com/innerpeace/themoonha/global/service/S3Service.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.innerpeace.themoonha.global.exception.CustomException;
 import com.innerpeace.themoonha.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
@@ -32,11 +33,14 @@ import java.util.UUID;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class S3Service {
     private final AmazonS3 s3Client;
 
     @Value("${aws.bucket}")
     private String bucket;
+    @Value("${aws.cloudfront.url}")
+    private String cloudFrontUrl;
 
     public String saveFile(MultipartFile multipartFile, String folderName) throws IOException {
         String originalFilename = getFileNameServer(multipartFile);
@@ -45,9 +49,9 @@ public class S3Service {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(multipartFile.getSize());
         metadata.setContentType(multipartFile.getContentType());
-
         s3Client.putObject(bucket, fullPath, multipartFile.getInputStream(), metadata);
-        return s3Client.getUrl(bucket, fullPath).toString();
+        log.info("url = {} ", cloudFrontUrl + " " + s3Client.getUrl(bucket, fullPath).getPath());
+        return cloudFrontUrl + s3Client.getUrl(bucket, fullPath).getPath();
     }
 
     public List<String> saveFiles(List<MultipartFile> files, String path) {

--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -106,6 +106,8 @@
         WHERE
             s.deleted_at IS NULL AND
             s.expire_date > sysdate
+        ORDER BY
+            s.short_form_id desc
     </select>
 
     <select id="selectLessonDetail"


### PR DESCRIPTION
# 💡 PR 요약
CloudFront 설정으로 인해 S3로의 직접적인 접근이 불가능합니다.
따라서, 파일 업로드 시 CloudFront에서 제공해주는 도메인 url을 바탕으로 url을 만들어 DB에 등록해야합니다.

## ⭐️ 관련 이슈
- closes : #102 

## 📍 작업한 내용
- S3Service.saveFile 메서드의 return url cloudfront 도메인 추가

## 🔎 결과 및 이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
