### PR TITLE
[LOUNGE] [KAN-28] 라운지 데이터 조회 시 회원 권한 적용

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
@@ -44,7 +44,7 @@ public class LoungeController {
     @GetMapping("/list")
     public ResponseEntity<List<LoungeListResponse>> loungeList() {
         Long memberId = 1L; // 임시 memberId
-        String role = "ROLE_MEMBER";
+        String role = "ROLE_TUTOR";
         return ResponseEntity.ok(loungeService.findLoungeList(memberId, role));
     }
 

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
@@ -68,7 +68,8 @@ public class LoungeController {
      */
     @GetMapping("/{loungeId}/post/{loungePostId}")
     public ResponseEntity<LoungePostDetailDTO> loungePostDetails(@PathVariable Long loungeId, @PathVariable Long loungePostId) {
-        return ResponseEntity.ok(loungeService.findLoungePostDetail(loungePostId));
+        Long memberId = 1L;
+        return ResponseEntity.ok(loungeService.findLoungePostDetail(loungePostId, memberId));
     }
 
     /**

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeCommentDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeCommentDTO.java
@@ -24,8 +24,10 @@ public class LoungeCommentDTO {
     private String content;
     private String createdAt;
     private LoungeMemberDTO loungeMember;
+    private boolean permissionYn;
 
     public void setCreatedAt(String createdAt) {
         this.createdAt = DateTimeUtil.timeAgo(createdAt);
     }
+
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
@@ -32,8 +32,10 @@ public class LoungeHomeResponse {
     public static LoungeHomeResponse of(LoungeInfoDTO loungeInfo,List<LoungePostDTO> loungePostList,
                                         List<AttendanceDTO> attendanceList, List<LoungeMemberDTO> loungeMemberList) {
 
+        // 공지 게시글 리스트 생성
         List<LoungePostDTO> loungeNoticePostList = loungePostList.stream()
                 .filter(LoungePostDTO::isNoticeYn)
+                .map(post -> LoungePostDTO.of(post, null))
                 .collect(Collectors.toList());
 
         return LoungeHomeResponse.builder()

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
@@ -24,5 +24,6 @@ public class LoungeInfoDTO {
     private String loungeImgUrl;
     private Long tutorId;
     private String tutorName;
+    private String tutorImgUrl;
     private String summary;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeInfoDTO.java
@@ -26,4 +26,5 @@ public class LoungeInfoDTO {
     private String tutorName;
     private String tutorImgUrl;
     private String summary;
+    private boolean permissionYn;
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungePostDTO.java
@@ -34,6 +34,8 @@ public class LoungePostDTO {
     // 작성자 정보
     private LoungeMemberDTO loungeMember;
 
+    private boolean permissionYn;
+
 
     public static LoungePostDTO of(LoungePostDTO loungePostDTO, List<String> loungePostImgList) {
         return LoungePostDTO.builder()
@@ -43,6 +45,7 @@ public class LoungePostDTO {
                 .loungePostImgList(loungePostImgList != null ? loungePostImgList : new ArrayList<>())
                 .createdAt(DateTimeUtil.timeAgo(loungePostDTO.getCreatedAt()))
                 .loungeMember(loungePostDTO.getLoungeMember())
+                .permissionYn(loungePostDTO.permissionYn)
                 .build();
     }
 

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
@@ -37,14 +37,14 @@ public interface LoungeMapper {
      * @param loungeId
      * @return
      */
-    Optional<LoungeInfoDTO> selectLoungeInfo(Long loungeId);
+    Optional<LoungeInfoDTO> selectLoungeInfo(@Param("loungeId") Long loungeId, @Param("memberId") Long memberId);
 
     /**
      * 라운지 게시글 목록 조회
      * @param loungeId
      * @return
      */
-    List<LoungePostDTO> selectLoungePostList(Long loungeId);
+    List<LoungePostDTO> selectLoungePostList(@Param("loungeId") Long loungeId, @Param("memberId") Long memberId);
 
     /**
      * 라운지 게시글 이미지 목록 조회
@@ -76,14 +76,14 @@ public interface LoungeMapper {
      * @param loungePostId
      * @return
      */
-    Optional<LoungePostDTO> selectLoungePostDetail(Long loungePostId);
+    Optional<LoungePostDTO> selectLoungePostDetail(@Param("loungePostId") Long loungePostId, @Param("memberId") Long memberId);
 
     /**
      * 라운지 게시글 한 건의 댓글 조회
      * @param loungePostId
      * @return
      */
-    List<LoungeCommentDTO> selectLoungeCommentList(Long loungePostId);
+    List<LoungeCommentDTO> selectLoungeCommentList(@Param("loungePostId") Long loungePostId, @Param("memberId") Long memberId);
 
     /**
      * 라운지 게시물 등록

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
@@ -46,7 +46,7 @@ public interface LoungeService {
      * @param loungePostId
      * @return
      */
-    LoungePostDetailDTO findLoungePostDetail(Long loungePostId);
+    LoungePostDetailDTO findLoungePostDetail(Long loungePostId, Long memberId);
 
     /**
      * 라운지 게시글 등록

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -66,9 +66,9 @@ public class LoungeServiceImpl implements LoungeService {
      */
     @Override
     public LoungeHomeResponse findLoungeHome(Long loungeId, Long memberId, String role) {
-        LoungeInfoDTO loungeInfo = loungeMapper.selectLoungeInfo(loungeId)
+        LoungeInfoDTO loungeInfo = loungeMapper.selectLoungeInfo(loungeId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.LOUNGE_NOT_FOUND));
-        List<LoungePostDTO> loungePostList = loungeMapper.selectLoungePostList(loungeId)
+        List<LoungePostDTO> loungePostList = loungeMapper.selectLoungePostList(loungeId, memberId)
                 .stream()
                 .map(loungePost -> {
                     List<String> postImgUrl = loungeMapper.selectLoungePostImgList(loungePost.getLoungePostId());
@@ -92,15 +92,15 @@ public class LoungeServiceImpl implements LoungeService {
      * @return
      */
     @Override
-    public LoungePostDetailDTO findLoungePostDetail(Long loungePostId) {
+    public LoungePostDetailDTO findLoungePostDetail(Long loungePostId, Long memberId) {
 
-        LoungePostDTO loungePost = loungeMapper.selectLoungePostDetail(loungePostId)
+        LoungePostDTO loungePost = loungeMapper.selectLoungePostDetail(loungePostId, memberId)
                 .map(loungePostDTO -> {
                     List<String> postImgUrl = loungeMapper.selectLoungePostImgList(loungePostDTO.getLoungePostId());
                     return LoungePostDTO.of(loungePostDTO, postImgUrl);
                 })
                 .orElseThrow(() -> new CustomException(ErrorCode.LOUNGE_POST_NOT_FOUND));
-        List<LoungeCommentDTO> loungeCommentList = loungeMapper.selectLoungeCommentList(loungePostId);
+        List<LoungeCommentDTO> loungeCommentList = loungeMapper.selectLoungeCommentList(loungePostId, memberId);
         return LoungePostDetailDTO.of(
                 loungePost,
                 loungeCommentList

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -108,7 +108,7 @@ public class LoungeServiceImpl implements LoungeService {
     }
 
     /**
-     * 라운지 게시물 수정
+     * 라운지 게시물 등록
      * @param loungePostRequest
      * @param memberId
      * @param loungePostImgs

--- a/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
+++ b/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
@@ -52,8 +52,8 @@ public class DateTimeUtil {
     }
 
     private static String formatDate(LocalDateTime time) {
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a hh시 mm분", Locale.KOREAN);
-        return time.format(dateFormatter).replace("AM", "오전").replace("PM", "오후");
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd. HH:mm", Locale.KOREAN);
+        return time.format(dateFormatter);
     }
 }
 

--- a/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
+++ b/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
@@ -24,8 +24,18 @@ public class DateTimeUtil {
             return "";
         }
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        LocalDateTime timeObj = LocalDateTime.parse(timeString, formatter);
+        DateTimeFormatter[] formatters = {
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.getDefault()),  // yyyy-MM-dd 형식
+                DateTimeFormatter.ofPattern("yyyy.MM.dd. HH:mm", Locale.getDefault())     // yyyy.MM.dd 형식
+        };
+
+        LocalDateTime timeObj = null;
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                timeObj = LocalDateTime.parse(timeString.trim(), formatter);
+            } catch (Exception e) {}
+        }
+
         LocalDateTime now = LocalDateTime.now();
 
         Duration duration = Duration.between(timeObj, now);

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -100,6 +100,7 @@
             lo.lounge_img_url,
             m.member_id AS tutor_id,
             m.name AS tutor_name,
+            m.profile_img_url AS tutorImgUrl,
             le.summary
         FROM
             lesson le

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -77,16 +77,16 @@
             lo.deleted_at IS NULL
           AND le.deleted_at IS NULL
           AND (
-            (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 2
-                AND le.member_id = #{memberId}
+                (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 2
+                    AND le.member_id = #{memberId}
                 OR
-            (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 1
-                AND lo.lesson_id IN (
-                SELECT s.lesson_id
-                FROM sugang s
-                WHERE s.member_id = #{memberId}
-                  AND s.lounge_yn = 1
-                  AND s.deleted_at IS NULL
+                (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 1
+                    AND lo.lesson_id IN (
+                    SELECT s.lesson_id
+                    FROM sugang s
+                    WHERE s.member_id = #{memberId}
+                      AND s.lounge_yn = 1
+                      AND s.deleted_at IS NULL
                 )
             )
            OR (

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -34,6 +34,7 @@
         <id property="loungeCommentId" column="lounge_comment_id"/>
         <result property="content" column="content"/>
         <result property="createdAt" column="created_at"/>
+        <result property="permissionYn" column="permission_yn" javaType="boolean"/>
         <association property="loungeMember" resultMap="LoungeMemberMap"/>
     </resultMap>
 
@@ -43,6 +44,7 @@
         <result property="content" column="content"/>
         <result property="noticeYn" column="notice_yn"/>
         <result property="createdAt" column="created_at"/>
+        <result property="permissionYn" column="permission_yn" javaType="boolean"/>
         <association property="loungeMember" resultMap="LoungeMemberMap"/>
     </resultMap>
 
@@ -62,31 +64,36 @@
             lp.created_at AS latest_post_time
         FROM
             lounge lo
-            JOIN lesson le ON lo.lesson_id = le.lesson_id
-            LEFT JOIN lounge_post lp ON lo.lounge_id = lp.lounge_id
-            AND lp.created_at = (
-                SELECT /*+ INDEX_DESC(lp PK_LOUNGE_POST) */
-                    MAX(created_at)
-                FROM lounge_post
-                WHERE lounge_id = lo.lounge_id
-                    AND deleted_at IS NULL
-            )
+                JOIN lesson le ON lo.lesson_id = le.lesson_id
+                LEFT JOIN lounge_post lp ON lo.lounge_id = lp.lounge_id
+                AND lp.created_at = (
+                    SELECT /*+ INDEX_DESC(lp PK_LOUNGE_POST) */
+                        MAX(created_at)
+                    FROM lounge_post
+                    WHERE lounge_id = lo.lounge_id
+                      AND deleted_at IS NULL
+                )
         WHERE
             lo.deleted_at IS NULL
-            AND le.deleted_at IS NULL
-            <if test="role == 'ROLE_MEMBER'">
-                AND lo.lesson_id IN (
-                    SELECT s.lesson_id
-                    FROM sugang s
-                    WHERE s.member_id = #{memberId}
-                        AND s.lounge_yn = 1
-                        AND s.deleted_at IS NULL
-                )
-            </if>
-            <if test="role == 'ROLE_TUTOR'">
+          AND le.deleted_at IS NULL
+          AND (
+            (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 2
                 AND le.member_id = #{memberId}
-            </if>
-            AND (lp.lounge_post_id IS NULL OR lp.deleted_at IS NULL)
+                OR
+            (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 1
+                AND lo.lesson_id IN (
+                SELECT s.lesson_id
+                FROM sugang s
+                WHERE s.member_id = #{memberId}
+                  AND s.lounge_yn = 1
+                  AND s.deleted_at IS NULL
+                )
+            )
+           OR (
+               (SELECT m.member_role FROM member m WHERE m.member_id = #{memberId}) = 0
+                   AND (1 = 1)
+                )
+          AND (lp.lounge_post_id IS NULL OR lp.deleted_at IS NULL)
         ORDER BY
             lo.lounge_id DESC
     </select>
@@ -101,7 +108,12 @@
             m.member_id AS tutor_id,
             m.name AS tutor_name,
             m.profile_img_url AS tutorImgUrl,
-            le.summary
+            le.summary,
+            CASE
+                WHEN (SELECT member_role FROM member WHERE member_id = #{memberId}) IN (0) THEN 1
+                WHEN le.member_id = #{memberId} THEN 1
+                ELSE 0
+            END AS permission_yn
         FROM
             lesson le
                 JOIN member m ON le.member_id = m.member_id
@@ -120,7 +132,12 @@
             lp.created_at,
             lm.member_id,
             lm.name,
-            lm.profile_img_url
+            lm.profile_img_url,
+            CASE
+                WHEN (SELECT member_role FROM member WHERE member_id = #{memberId}) IN (2, 0) THEN 1
+                WHEN lp.member_id = #{memberId} THEN 1
+                ELSE 0
+            END AS permission_yn
         FROM
             lounge_post lp
                 LEFT JOIN member lm ON lp.member_id = lm.member_id
@@ -202,7 +219,12 @@
             lp.created_at,
             lm.member_id,
             lm.name,
-            lm.profile_img_url
+            lm.profile_img_url,
+            CASE
+                WHEN (SELECT member_role FROM member WHERE member_id = #{memberId}) IN (2, 0) THEN 1
+                WHEN lp.member_id = #{memberId} THEN 1
+                ELSE 0
+            END AS permission_yn
         FROM
             lounge_post lp
                 LEFT JOIN member lm ON lp.member_id = lm.member_id
@@ -220,7 +242,12 @@
             lc.created_at,
             lcm.member_id,
             lcm.name,
-            lcm.profile_img_url
+            lcm.profile_img_url,
+            CASE
+                WHEN (SELECT member_role FROM member WHERE member_id = #{memberId}) IN (2, 0) THEN 1
+                WHEN lc.member_id = #{memberId} THEN 1
+                ELSE 0
+            END AS permission_yn
         FROM
             lounge_comment lc
                 LEFT JOIN member lcm ON lc.member_id = lcm.member_id


### PR DESCRIPTION
# 💡 PR 요약
회원의 권한에 따라 라운지 데이터를 다르게 표시하도록 변경했습니다.
게시물, 댓글에 수정/삭제 권한이 있는지 확인하기 위해 permissionYn이라는 필드를 추가하였습니다.

## ⭐️ 관련 이슈
- closes : #76 

## 📍 작업한 내용
- 강사: 자신이 수업하는 강좌 라운지만 보이도록
- 회원: 자신이 듣는 강좌 라운지만 보이도록

## 🔎 결과 및 이슈 공유
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/1e5ee17b-9ea1-43f9-a703-3eb26db0409d">



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
