### PR TITLE
[SCHEDULE] [KAN-28] 다음 스케줄 보기 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/schedule/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.schedule.controller;
 
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleMonthlyResponse;
+import com.innerpeace.themoonha.domain.schedule.dto.ScheduleNextResponse;
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleWeeklyResponse;
 import com.innerpeace.themoonha.domain.schedule.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import java.util.List;
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       스케줄 주간 보기 기능 구현
  * 2024.09.09  	조희정       스케줄 월간 보기 기능 구현
+ * 2024.09.09  	조희정       다음 스케줄 보기 기능 구현
  * </pre>
  */
 @RestController
@@ -55,5 +57,15 @@ public class ScheduleController {
     public ResponseEntity<List<ScheduleMonthlyResponse>>scheduleMonthly(@RequestParam String yearMonth) {
         Long memberId = 1L;
         return ResponseEntity.ok(scheduleService.findMonthlySchedules(memberId, yearMonth));
+    }
+
+    /**
+     * 다음 스케줄 보기
+     * @return
+     */
+    @GetMapping("/next")
+    public ResponseEntity<ScheduleNextResponse>scheduleNext() {
+        Long memberId = 1L;
+        return ResponseEntity.ok(scheduleService.findNextSchedule(memberId));
     }
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/schedule/dto/ScheduleNextResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/schedule/dto/ScheduleNextResponse.java
@@ -1,0 +1,33 @@
+package com.innerpeace.themoonha.domain.schedule.dto;
+
+import lombok.*;
+
+/**
+ * 스케줄 월간보기 응답 DTO
+ * @author 조희정
+ * @since 2024.09.09
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.09  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ScheduleNextResponse {
+    private Long lessonId;
+    private String branchName;
+    private String lessonTitle;
+    private int cnt;
+    private String period;
+    private String lessonTime;
+    private String tutorName;
+    private String target;
+    private Long loungeId;
+    private boolean onlineYn;
+}
+

--- a/src/main/java/com/innerpeace/themoonha/domain/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/schedule/mapper/ScheduleMapper.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.schedule.mapper;
 
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleMonthlyResponse;
+import com.innerpeace.themoonha.domain.schedule.dto.ScheduleNextResponse;
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleWeeklyResponse;
 import org.apache.ibatis.annotations.Param;
 
@@ -18,6 +19,7 @@ import java.util.List;
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       스케줄 주간 보기 기능 구현
  * 2024.09.09  	조희정       스케줄 월간 보기 기능 구현
+ * 2024.09.09  	조희정       다음 강의 조회 기능 구현
  * </pre>
  */
 public interface ScheduleMapper {
@@ -37,4 +39,11 @@ public interface ScheduleMapper {
      * @return
      */
     List<ScheduleMonthlyResponse> selectMonthlySchedules(@Param("memberId") Long memberId, @Param("yearMonth") String yearMonth);
+
+    /**
+     * 다음 강의 조회
+     * @param memberId
+     * @return
+     */
+    ScheduleNextResponse selectNextSchedule(Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/schedule/service/ScheduleService.java
@@ -1,9 +1,11 @@
 package com.innerpeace.themoonha.domain.schedule.service;
 
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleMonthlyResponse;
+import com.innerpeace.themoonha.domain.schedule.dto.ScheduleNextResponse;
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleWeeklyResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 스케줄 서비스 인터페이스
@@ -17,6 +19,7 @@ import java.util.List;
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       스케줄 주간 보기 구현
  * 2024.09.09  	조희정       스케줄 월간 보기 구현
+ * 2024.09.09  	조희정       댜음 강좌 보기 구현
  * </pre>
  */
 public interface ScheduleService {
@@ -36,4 +39,11 @@ public interface ScheduleService {
      * @return
      */
     List<ScheduleMonthlyResponse> findMonthlySchedules(Long memberId, String yearMonth);
+
+    /**
+     * 다음 스케줄 조회
+     * @param memberId
+     * @return
+     */
+    ScheduleNextResponse findNextSchedule(Long memberId);
 }

--- a/src/main/java/com/innerpeace/themoonha/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.domain.schedule.service;
 
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleMonthlyResponse;
+import com.innerpeace.themoonha.domain.schedule.dto.ScheduleNextResponse;
 import com.innerpeace.themoonha.domain.schedule.dto.ScheduleWeeklyResponse;
 import com.innerpeace.themoonha.domain.schedule.mapper.ScheduleMapper;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       스케줄 주간 보기 구현
  * 2024.09.09  	조희정       스케줄 월간 보기 구현
+ * 2024.09.09  	조희정       다음 스케줄 조회 구현
  * </pre>
  */
 @Service
@@ -66,5 +68,13 @@ public class ScheduleServiceImpl implements ScheduleService{
         return scheduleMapper.selectMonthlySchedules(memberId, yearMonth);
     }
 
-
+    /**
+     * 댜음 스케줄 조회
+     * @param memberId
+     * @return
+     */
+    @Override
+    public ScheduleNextResponse findNextSchedule(Long memberId) {
+        return scheduleMapper.selectNextSchedule(memberId);
+    }
 }

--- a/src/main/resources/com/innerpeace/themoonha/domain/schedule/mapper/ScheduleMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/schedule/mapper/ScheduleMapper.xml
@@ -78,4 +78,37 @@
             ORDER BY l.start_date, l.start_time
         ]]>
     </select>
+
+    <select id="selectNextSchedule" resultType="com.innerpeace.themoonha.domain.schedule.dto.ScheduleNextResponse">
+        SELECT /*+ FIRST_ROWS(1) */
+            l.lesson_id,
+            b.name AS branch_name,
+            l.title AS lesson_title,
+            l.cnt,
+            l.start_date || '~' || l.end_date AS period,
+            CASE
+                WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
+                END AS lesson_time,
+            m.name AS tutor_name,
+            l.target,
+            lo.lounge_id,
+            l.online_yn
+        FROM (
+                 SELECT l.lesson_id, l.title, l.branch_id, l.member_id, l.cnt, l.start_date, l.end_date, l.start_time, l.end_time, l.day, l.target, s.online_yn
+                 FROM lesson l
+                          JOIN sugang s ON l.lesson_id = s.lesson_id
+                 WHERE s.member_id = #{memberId}
+                   AND s.deleted_at IS NULL
+                   AND l.deleted_at IS NULL
+                   AND TRUNC(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul') BETWEEN l.start_date AND l.end_date
+                   AND INSTR(l.day, TO_CHAR(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul', 'DY', 'NLS_DATE_LANGUAGE=KOREAN')) > 0
+                   AND l.start_time > TO_CHAR(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul', 'HH24:MI')
+                 ORDER BY l.start_date, l.start_time
+                     FETCH FIRST 1 ROWS ONLY
+             ) l
+                 JOIN member m ON l.member_id = m.member_id
+                 JOIN branch b ON l.branch_id = b.branch_id
+                 LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
다음 스케줄 보기 구현

## ⭐️ 관련 이슈
- closes : #107

## 📍 작업한 내용
- 오늘 기준 다음 스케줄 보기 구현

## 🔎 결과 및 이슈 공유
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7c2f9f93-8d97-431b-8b18-494c9d67b9b6">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
