### PR TITLE
[LOUNGE] [KAN-23] 출결 상태 조회 구현

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/controller/LoungeController.java
@@ -27,6 +27,7 @@ import java.util.List;
  * 2024.08.28  	조희정       게시글 수정, 댓글 삭제, 댓글 수정 구현
  * 2024.08.29  	조희정       출석 시작 구현
  * 2024.08.30  	조희정       수강생 출석 여부 수정 구현
+ * 2024.09.10  	조희정       출석 현황 조회 구현
  * </pre>
  */
 @RestController
@@ -146,8 +147,8 @@ public class LoungeController {
      * @param lessonId
      * @return
      */
-    @PostMapping("/attendance")
-    public ResponseEntity<List<AttendanceDTO>> loungeAttendanceList(@RequestBody Long lessonId) {
+    @PostMapping("/attendance/{lessonId}")
+    public ResponseEntity<List<AttendanceDTO>> loungeAttendanceList(@PathVariable Long lessonId) {
         return ResponseEntity.ok(loungeService.saveAttendanceList(lessonId));
     }
 
@@ -156,8 +157,8 @@ public class LoungeController {
      * @param attendanceId
      * @return
      */
-    @PostMapping("/attendance/update")
-    public ResponseEntity<CommonResponse> loungeAttendanceUpdate(@RequestBody Long attendanceId) {
+    @PostMapping("/attendance/update/{attendanceId}")
+    public ResponseEntity<CommonResponse> loungeAttendanceUpdate(@PathVariable Long attendanceId) {
         return ResponseEntity.ok(loungeService.modifyAttendanceYn(attendanceId));
     }
 

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceDTO.java
@@ -26,6 +26,7 @@ public class AttendanceDTO {
     private Long attendanceId;
     private Long memberId;
     private String name;
+    private String profileImgUrl;
     private String attendanceDate;
     private Boolean attendanceYn;
 

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceMembersDTO.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceMembersDTO.java
@@ -1,0 +1,27 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 수강생 출석 정보 DTO
+ * @author 조희정
+ * @since 2024.09.10
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.10  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceMembersDTO {
+    private String name;
+    private long attendanceCnt;
+    private List<Boolean> attendance;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceMembersResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/AttendanceMembersResponse.java
@@ -1,0 +1,26 @@
+package com.innerpeace.themoonha.domain.lounge.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 수강생 출석 정보 응답 DTO
+ * @author 조희정
+ * @since 2024.09.10
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.10  	조희정       최초 생성
+ * </pre>
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceMembersResponse {
+    private List<String> attendanceDates;
+    private List<AttendanceMembersDTO> students;
+}

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/dto/LoungeHomeResponse.java
@@ -26,11 +26,11 @@ public class LoungeHomeResponse {
     private LoungeInfoDTO loungeInfo;
     private List<LoungePostDTO> loungeNoticePostList;
     private List<LoungePostDTO> loungePostList;
-    private List<AttendanceDTO> attendanceList;
+    private AttendanceMembersResponse attendanceList;
     private List<LoungeMemberDTO> loungeMemberList;
 
     public static LoungeHomeResponse of(LoungeInfoDTO loungeInfo,List<LoungePostDTO> loungePostList,
-                                        List<AttendanceDTO> attendanceList, List<LoungeMemberDTO> loungeMemberList) {
+                                        AttendanceMembersResponse attendanceList, List<LoungeMemberDTO> loungeMemberList) {
 
         // 공지 게시글 리스트 생성
         List<LoungePostDTO> loungeNoticePostList = loungePostList.stream()

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.java
@@ -161,12 +161,12 @@ public interface LoungeMapper {
     int insertAttendanceList(@Param("lessonId") Long lessonId, @Param("currentTime") String currentTime);
 
     /**
-     * 출석 시작 리스트 조회
+     * 출석 리스트 조회
      * @param lessonId
      * @param currentTime
      * @return
      */
-    List<AttendanceDTO> selectAttendanceStartedList(@Param("lessonId") Long lessonId, @Param("currentTime") String currentTime);
+    List<AttendanceDTO> selectAttendanceStartedList(@Param("lessonId") Long lessonId, @Param("currentTime") String currentTime, @Param("memberId") Long memebrId);
 
     /**
      * 수강생 출석 여부 수정

--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeService.java
@@ -22,6 +22,7 @@ import java.util.List;
  * 2024.08.28  	조희정       게시글 수정, 댓글 삭제, 댓글 수정 구현
  * 2024.08.29  	조희정       출석 시작 구현
  * 2024.08.30  	조희정       수강생 출석 여부 수정 구현
+ * 2024.09.10  	조희정       출석 현황 조회 구현
  * </pre>
  */
 public interface LoungeService {
@@ -110,4 +111,13 @@ public interface LoungeService {
      * @return
      */
     CommonResponse modifyAttendanceYn(Long attendanceId);
+
+    /**
+     * 출석 현황 조회
+     * @param lessonId
+     * @param memberId
+     * @return
+     */
+    AttendanceMembersResponse findAllMemberAttendance(Long lessonId, Long memberId);
+
 }

--- a/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
+++ b/src/main/java/com/innerpeace/themoonha/global/util/DateTimeUtil.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 public class DateTimeUtil {
 
     public static String timeAgo(String timeString) {
-        if (timeString == null) {
+        if (timeString == null || timeString.trim().isEmpty()) {
             return "";
         }
 
@@ -33,11 +33,16 @@ public class DateTimeUtil {
         for (DateTimeFormatter formatter : formatters) {
             try {
                 timeObj = LocalDateTime.parse(timeString.trim(), formatter);
-            } catch (Exception e) {}
+                break;
+            } catch (Exception e) {
+            }
+        }
+
+        if (timeObj == null) {
+            return "";
         }
 
         LocalDateTime now = LocalDateTime.now();
-
         Duration duration = Duration.between(timeObj, now);
 
         // 오늘 이전이라면 날짜 그대로 반환

--- a/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lounge/mapper/LoungeMapper.xml
@@ -385,6 +385,7 @@
             a.attendance_id,
             s.member_id,
             m.name,
+            m.profile_img_url,
             a.attendance_date,
             a.attendance_yn
         FROM
@@ -395,7 +396,12 @@
             member m ON s.member_id = m.member_id
         WHERE
             s.lesson_id = #{lessonId}
+            <if test="memberId != null">
+                AND s.member_id = #{memberId}
+            </if>
+            <if test="currentTime != null">
                 AND a.attendance_date = TO_DATE(#{currentTime}, 'YYYY-MM-DD')
+            </if>
     </select>
 
     <!-- 수강생 출석 여부 수정 -->


### PR DESCRIPTION
# 💡 PR 요약
출결 상태 조회 구현을 위해 라운지 홈 조회 API를 수정하였습니다.

## ⭐️ 관련 이슈
- closes : #112 

## 📍 작업한 내용
- 라운지 홈 조회 API의 AttendanceList 수정

## 🔎 결과 및 이슈 공유
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/696cb00f-288b-4e4a-836b-54cf712db02c">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
