### PR TITLE
[BITE] [KAN-23] 분야별 한입 등록시 강좌 목록 불러오는 쿼리 수정

### DIFF
--- a/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/lesson/mapper/LessonMapper.xml
@@ -264,19 +264,15 @@
 
     <select id="selectLessonFieldEnrollList"
             resultType="com.innerpeace.themoonha.domain.lesson.dto.LessonEnrollResponse">
-        SELECT
-            s.lesson_id, l.title
-        FROM
-            sugang s
-        JOIN
-            lesson l on s.lesson_id = l.lesson_id
-        LEFT JOIN
-            field f on l.lesson_id = f.lesson_id AND f.member_id = #{memberId}
-        WHERE
-            s.member_id = #{memberId} and
-            sysdate > TO_DATE(l.start_date, 'YYYY-MM-DD') and
-        ORDER BY
-            s.lesson_id
+        select
+            lesson_id, title
+        FROM lesson
+        WHERE lesson_id IN (
+            SELECT lesson_id
+            FROM sugang
+            WHERE member_id = #{memberId}
+        ) AND sysdate > TO_DATE(start_date, 'YYYY-MM-DD')
+        ORDER BY lesson_id;
     </select>
 
     <select id="selectTutorLessonList"


### PR DESCRIPTION
# 💡 PR 요약
분야별 한입 등록시 강좌 목록 불러오는 쿼리 수정했습니다. 

## ⭐️ 관련 이슈
- closes : #164 

## 📍 작업한 내용
- 분야별 한입 등록시 강좌 목록 불러오는 쿼리 수정

## 🔎 결과 및 이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
