### PR TITLE
[SCHEDULE] [KAN-24] 스케줄 불러올 때 라운지 참여 여부 반영

### DIFF
--- a/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
+++ b/src/main/java/com/innerpeace/themoonha/domain/lounge/service/LoungeServiceImpl.java
@@ -81,9 +81,9 @@ public class LoungeServiceImpl implements LoungeService {
 
         AttendanceMembersResponse attendanceMembersResponse;
         if (role.equals("ROLE_TUTOR")) {
-            attendanceMembersResponse = findAllMemberAttendance(loungeId, null);
+            attendanceMembersResponse = findAllMemberAttendance(loungeInfo.getLessonId(), null);
         } else {
-            attendanceMembersResponse = findAllMemberAttendance(loungeId, memberId);
+            attendanceMembersResponse = findAllMemberAttendance(loungeInfo.getLessonId(), memberId);
         }
         List<LoungeMemberDTO> loungeMemberList = loungeMapper.selectLoungeMemberList(loungeInfo.getLessonId());
 

--- a/src/main/resources/com/innerpeace/themoonha/domain/schedule/mapper/ScheduleMapper.xml
+++ b/src/main/resources/com/innerpeace/themoonha/domain/schedule/mapper/ScheduleMapper.xml
@@ -22,90 +22,98 @@
     <!-- 주별 스케줄 가져오기 -->
     <select id="selectWeeklySchedules" resultType="com.innerpeace.themoonha.domain.schedule.dto.ScheduleWeeklyResponse">
         <foreach collection="standardDates" item="standardDate" separator="UNION ALL">
-                SELECT
-                    l.lesson_id,
-                    l.day,
-                    SUBSTR(l.start_time, 1, 2) AS start_hour,
-                    SUBSTR(l.start_time, 4, 2) AS start_minute,
-                    SUBSTR(l.end_time, 1, 2) AS end_hour,
-                    SUBSTR(l.end_time, 4, 2) AS end_minute,
-                    l.title,
-                    #{standardDate} AS standard_date,
-                    b.name AS branch_name,
-                    l.cnt,
-                    l.start_date || '~' || l.end_date AS period,
-                    CASE
-                        WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
-                        ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
-                    END AS lesson_time,
-                    m.name AS tutor_name,
-                    lo.lounge_id
-                FROM
-                    lesson l
-                    JOIN branch b ON l.branch_id = b.branch_id
-                    JOIN member m ON l.member_id = m.member_id
-                    LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
-                WHERE
+            SELECT
+                l.lesson_id,
+                l.day,
+                SUBSTR(l.start_time, 1, 2) AS start_hour,
+                SUBSTR(l.start_time, 4, 2) AS start_minute,
+                SUBSTR(l.end_time, 1, 2) AS end_hour,
+                SUBSTR(l.end_time, 4, 2) AS end_minute,
+                l.title,
+                #{standardDate} AS standard_date,
+                b.name AS branch_name,
+                l.cnt,
+                l.start_date || '~' || l.end_date AS period,
+                CASE
+                    WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                    ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
+                END AS lesson_time,
+                m.name AS tutor_name,
+                CASE
+                    WHEN s.lounge_yn = 0 THEN 0
+                    ELSE lo.lounge_id
+                END AS lounge_id
+            FROM
+                lesson l
+                JOIN branch b ON l.branch_id = b.branch_id
+                JOIN member m ON l.member_id = m.member_id
+                LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
                 <if test="role == 'ROLE_MEMBER'">
-                    l.lesson_id IN (
-                        SELECT s.lesson_id
-                        FROM sugang s
-                        WHERE s.member_id = #{memberId}
-                        AND s.deleted_at IS NULL
-                    )
+                    JOIN sugang s ON l.lesson_id = s.lesson_id
                 </if>
-                <if test="role != 'ROLE_MEMBER'">
-                    l.member_id = #{memberId}
-                </if>
+            WHERE
+            <if test="role == 'ROLE_MEMBER'">
+                l.lesson_id IN (
+                SELECT s.lesson_id
+                FROM sugang s
+                WHERE s.member_id = #{memberId}
+                AND s.deleted_at IS NULL
+                )
+            </if>
+            <if test="role != 'ROLE_MEMBER'">
+                l.member_id = #{memberId}
+            </if>
             <![CDATA[
-                    AND l.deleted_at IS NULL
-                    AND (
-                        TO_DATE(l.start_date, 'YYYY-MM-DD') <= TO_DATE(#{standardDate}, 'YYYY-MM-DD') + INTERVAL '6' DAY
-                        AND TO_DATE(l.end_date, 'YYYY-MM-DD') >= TO_DATE(#{standardDate}, 'YYYY-MM-DD')
-                    )
+                AND l.deleted_at IS NULL
+                AND (
+                    TO_DATE(l.start_date, 'YYYY-MM-DD') <= TO_DATE(#{standardDate}, 'YYYY-MM-DD') + INTERVAL '6' DAY
+                    AND TO_DATE(l.end_date, 'YYYY-MM-DD') >= TO_DATE(#{standardDate}, 'YYYY-MM-DD')
+                )
             ]]>
         </foreach>
     </select>
 
     <!-- 월별 스케줄 가져오기 -->
     <select id="selectMonthlySchedules" resultType="com.innerpeace.themoonha.domain.schedule.dto.ScheduleMonthlyResponse">
-            SELECT
-                l.lesson_id,
-                b.name AS branch_name,
-                l.title AS lesson_title,
-                l.cnt,
-                l.start_date || '~' || l.end_date AS period,
-                CASE
-                    WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
-                    ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
-                    END AS lesson_time,
-                m.name AS tutor_name,
-                l.target,
-                lo.lounge_id
-            FROM
-                lesson l
-                    JOIN branch b ON l.branch_id = b.branch_id
-                    JOIN member m ON l.member_id = m.member_id
-                    LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
-                <if test="role == 'ROLE_MEMBER'">
-                    JOIN sugang s ON l.lesson_id = s.lesson_id
-                </if>
-            WHERE
-                <if test="role == 'ROLE_MEMBER'">
+        SELECT
+            l.lesson_id,
+            b.name AS branch_name,
+            l.title AS lesson_title,
+            l.cnt,
+            l.start_date || '~' || l.end_date AS period,
+            CASE
+                WHEN l.cnt = 1 THEN l.start_date || '(' || l.day || ') ' || l.start_time || '~' || l.end_time
+                ELSE '매주 ' || l.day || ' ' || l.start_time || '~' || l.end_time
+            END AS lesson_time,
+            m.name AS tutor_name,
+            l.target,
+            CASE
+                WHEN s.lounge_yn = 0 THEN 0
+                ELSE lo.lounge_id
+            END AS lounge_id
+        FROM
+            lesson l
+            JOIN branch b ON l.branch_id = b.branch_id
+            JOIN member m ON l.member_id = m.member_id
+            LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
+            <if test="role == 'ROLE_MEMBER'">
+                JOIN sugang s ON l.lesson_id = s.lesson_id
+            </if>
+        WHERE
+            <if test="role == 'ROLE_MEMBER'">
                 s.member_id = #{memberId}
-              AND s.deleted_at IS NULL
-                </if>
-                <if test="role != 'ROLE_MEMBER'">
+                AND s.deleted_at IS NULL
+            </if>
+            <if test="role != 'ROLE_MEMBER'">
                 l.member_id = #{memberId}
-                </if>
-              AND l.deleted_at IS NULL
+            </if>
+            AND l.deleted_at IS NULL
         <![CDATA[
-              AND SUBSTR(l.start_date, 1, 7) <= SUBSTR(#{yearMonth}, 1, 7)
-              AND SUBSTR(l.end_date, 1, 7) >= SUBSTR(#{yearMonth}, 1, 7)
-            ORDER BY l.start_date, l.start_time
+        AND SUBSTR(l.start_date, 1, 7) <= SUBSTR(#{yearMonth}, 1, 7)
+        AND SUBSTR(l.end_date, 1, 7) >= SUBSTR(#{yearMonth}, 1, 7)
+        ORDER BY l.start_date, l.start_time
         ]]>
     </select>
-
 
     <!-- 다음 스케줄 보기 -->
     <select id="selectNextSchedule" resultType="com.innerpeace.themoonha.domain.schedule.dto.ScheduleNextResponse">
@@ -121,13 +129,25 @@
             END AS lesson_time,
             m.name AS tutor_name,
             l.target,
-            lo.lounge_id
+            CASE
+                WHEN s.lounge_yn = 0 THEN 0
+                ELSE lo.lounge_id
+            END AS lounge_id
         FROM (
             SELECT l.lesson_id, l.title, l.branch_id, l.member_id, l.cnt, l.start_date, l.end_date, l.start_time, l.end_time, l.day, l.target
             FROM lesson l
-            <if test="role == 'ROLE_MEMBER'">
-                JOIN sugang s ON l.lesson_id = s.lesson_id
-            </if>
+            WHERE
+                l.deleted_at IS NULL
+                AND TRUNC(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul') BETWEEN l.start_date AND l.end_date
+                AND INSTR(l.day, TO_CHAR(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul', 'DY', 'NLS_DATE_LANGUAGE=KOREAN')) > 0
+                AND l.start_time > TO_CHAR(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul', 'HH24:MI')
+            ORDER BY l.start_date, l.start_time
+            FETCH FIRST 1 ROWS ONLY
+        ) l
+            JOIN member m ON l.member_id = m.member_id
+            JOIN branch b ON l.branch_id = b.branch_id
+            LEFT JOIN sugang s ON l.lesson_id = s.lesson_id
+            LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
             WHERE
             <if test="role == 'ROLE_MEMBER'">
                 s.member_id = #{memberId}
@@ -136,16 +156,5 @@
             <if test="role != 'ROLE_MEMBER'">
                 l.member_id = #{memberId}
             </if>
-                AND l.deleted_at IS NULL
-                AND TRUNC(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul') BETWEEN l.start_date AND l.end_date
-                AND INSTR(l.day, TO_CHAR(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul', 'DY', 'NLS_DATE_LANGUAGE=KOREAN')) > 0
-                AND l.start_time > TO_CHAR(SYSTIMESTAMP AT TIME ZONE 'Asia/Seoul', 'HH24:MI')
-            ORDER BY l.start_date, l.start_time
-            FETCH FIRST 1 ROWS ONLY
-        ) l
-        JOIN member m ON l.member_id = m.member_id
-        JOIN branch b ON l.branch_id = b.branch_id
-        LEFT JOIN lounge lo ON l.lesson_id = lo.lesson_id
     </select>
-
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
스케줄 불러올 때 라운지 참여 여부 반영

## ⭐️ 관련 이슈
- closes : #176 

## 📍 작업한 내용
- 스케줄 불러올 때 라운지 참여 여부 반영

## 🔎 결과 및 이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
